### PR TITLE
Added feature to include the road type in the MATSim output.

### DIFF
--- a/src/main/java/org/matsim/contrib/josm/actions/NetworkTest.java
+++ b/src/main/java/org/matsim/contrib/josm/actions/NetworkTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.matsim.contrib.josm.gui.Preferences;
 import org.matsim.contrib.josm.model.MATSimLayer;
 import org.matsim.contrib.josm.model.MLink;
 import org.matsim.contrib.josm.model.MNode;
@@ -147,7 +148,8 @@ public class NetworkTest extends Test {
 	 */
 	private boolean doubtfulAttributes(MLink link) {
 		return link.getFreespeed() == 0 || link.getCapacity() == 0 || link.getLength() == 0
-				|| link.getNumberOfLanes() == 0;
+				|| link.getNumberOfLanes() == 0
+				|| (Preferences.includeRoadType() && link.getType() == null);
 	}
 
 	/**

--- a/src/main/java/org/matsim/contrib/josm/gui/LinksToggleDialog.java
+++ b/src/main/java/org/matsim/contrib/josm/gui/LinksToggleDialog.java
@@ -182,7 +182,7 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 	// handles the underlying data of the links table
 	private class MATSimTableModel_links extends AbstractTableModel implements SelectionChangedListener, ListSelectionListener {
 
-		private final String[] columnNames = { "id", "internal-id", "length", "freespeed", "capacity", "permlanes", "modes" };
+		private final String[] columnNames = { "id", "internal-id", "length", "freespeed", "capacity", "permlanes", "modes", "type" };
 
 		private Map<Integer, MLink> links;
 
@@ -206,6 +206,8 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 			} else if (columnIndex == 5) {
 				return Double.class;
 			} else if (columnIndex == 6) {
+				return String.class;
+			} else if (columnIndex == 7) {
 				return String.class;
 			}
 			throw new RuntimeException();
@@ -244,6 +246,8 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 			} else if (columnIndex == 6) {
 				return link.getAllowedModes().toString();
 			} else if (columnIndex == 7) {
+				return link.getType();
+			} else if (columnIndex == 8) {
 				return link;
 			}
 			throw new RuntimeException();
@@ -282,7 +286,7 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 			if (currentDataSet != null) {
 				if (table_links.getSelectedRow() != -1) {
 					int row = table_links.convertRowIndexToModel(table_links.getSelectedRow());
-					MLink link = (MLink) this.getValueAt(row, 7);
+					MLink link = (MLink) this.getValueAt(row, 8);
 					if (link.getSegments() != null) {
 						List<WaySegment> segments = link.getSegments();
 						currentDataSet.setHighlightedWaySegments(segments);

--- a/src/main/java/org/matsim/contrib/josm/gui/Preferences.java
+++ b/src/main/java/org/matsim/contrib/josm/gui/Preferences.java
@@ -37,6 +37,7 @@ public final class Preferences extends DefaultTabPreferenceSetting {
 	private final JCheckBox cleanNetwork = new JCheckBox("Clean Network");
 	private final JCheckBox keepPaths = new JCheckBox("Keep Paths");
 	private final JButton convertingDefaults = new JButton("Set converting defaults");
+	private final JCheckBox includeRoadType = new JCheckBox("Include road type in output");
 	private final JCheckBox filterActive = new JCheckBox("Activate hierarchy filter");
 	private final JLabel hierarchyLabel = new JLabel("Only convert hierarchies up to: ");
 	private final JTextField hierarchyLayer = new JTextField();
@@ -75,6 +76,7 @@ public final class Preferences extends DefaultTabPreferenceSetting {
 		Main.pref.put("matsim_keepPaths", keepPaths.isSelected());
 		Main.pref.put("matsim_showInternalIds", showInternalIds.isSelected());
 		Main.pref.put("matsim_filterActive", filterActive.isSelected());
+		Main.pref.put("matsim_includeRoadType", includeRoadType.isSelected());
 		Main.pref.putInteger("matsim_filter_hierarchy", Integer.parseInt(hierarchyLayer.getText()));
 		Main.pref.putDouble("matsim_wayOffset", ((double) wayOffset.getValue()) * 0.03);
 		return false;
@@ -185,6 +187,7 @@ public final class Preferences extends DefaultTabPreferenceSetting {
 			dlg.dispose();
 		});
 
+		includeRoadType.setSelected(Main.pref.getBoolean("matsim_includeRoadType", false));
 		filterActive.setSelected(Main.pref.getBoolean("matsim_filterActive", false));
 		hierarchyLayer.setText(String.valueOf(Main.pref.getInteger("matsim_filter_hierarchy", 6)));
 
@@ -202,19 +205,22 @@ public final class Preferences extends DefaultTabPreferenceSetting {
 		pnl.add(transitLite, cOptions);
 
 		cOptions.gridx = 0;
-		cOptions.gridy = 1;
+		cOptions.gridy++;
 		pnl.add(cleanNetwork, cOptions);
 
-		cOptions.gridy = 2;
+		cOptions.gridy++;
 		pnl.add(keepPaths, cOptions);
 
-		cOptions.gridy = 3;
+		cOptions.gridy++;
 		pnl.add(convertingDefaults, cOptions);
 
-		cOptions.gridy = 4;
+		cOptions.gridy++;
+		pnl.add(includeRoadType, cOptions);
+
+		cOptions.gridy++;
 		pnl.add(filterActive, cOptions);
 
-		cOptions.gridy = 5;
+		cOptions.gridy++;
 		pnl.add(hierarchyLabel, cOptions);
 		cOptions.gridx = 1;
 		pnl.add(hierarchyLayer, cOptions);
@@ -224,7 +230,7 @@ public final class Preferences extends DefaultTabPreferenceSetting {
 		cOptions.fill = GridBagConstraints.HORIZONTAL;
 		cOptions.gridwidth = 2;
 		cOptions.gridx = 0;
-		cOptions.gridy = 6;
+		cOptions.gridy++;
 		JSeparator jSep = new JSeparator(SwingConstants.HORIZONTAL);
 		pnl.add(jSep, cOptions);
 
@@ -250,6 +256,8 @@ public final class Preferences extends DefaultTabPreferenceSetting {
 	public static void setSupportTransit(boolean supportTransit) {
 		Main.pref.put("matsim_supportTransit", supportTransit);
 	}
+
+	public static boolean includeRoadType() { return Main.pref.getBoolean("matsim_includeRoadType", false); }
 
 	public static boolean isTransitLite() {
 		return Main.pref.getBoolean("matsim_transit_lite", false);

--- a/src/main/java/org/matsim/contrib/josm/model/Export.java
+++ b/src/main/java/org/matsim/contrib/josm/model/Export.java
@@ -9,6 +9,7 @@ import org.matsim.api.core.v01.network.Node;
 import org.matsim.contrib.josm.gui.Preferences;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.pt.transitSchedule.api.*;
@@ -45,6 +46,9 @@ public class Export {
 				newLink.setLength(link.getLength());
 				newLink.setNumberOfLanes(link.getNumberOfLanes());
 				newLink.setAllowedModes(link.getAllowedModes());
+				if (Preferences.includeRoadType()) {
+					NetworkUtils.setType(newLink, link.getType());
+				}
 				scenario.getNetwork().addLink(newLink);
 			}
 		}

--- a/src/main/java/org/matsim/contrib/josm/model/Importer.java
+++ b/src/main/java/org/matsim/contrib/josm/model/Importer.java
@@ -7,6 +7,7 @@ import org.matsim.api.core.v01.network.Node;
 import org.matsim.contrib.josm.gui.Preferences;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.scenario.ScenarioUtils;
@@ -112,6 +113,11 @@ public class Importer {
 			way.put(LinkConversionRules.CAPACITY, String.valueOf(link.getCapacity()));
 			way.put(LinkConversionRules.LENGTH, String.valueOf(link.getLength()));
 			way.put(LinkConversionRules.PERMLANES, String.valueOf(link.getNumberOfLanes()));
+
+			if (NetworkUtils.getType(link) != null) {
+				way.put(LinkConversionRules.TYPE, String.valueOf(NetworkUtils.getType(link)));
+			}
+
 			StringBuilder modes = new StringBuilder();
 			for (String mode : link.getAllowedModes()) {
 				modes.append(mode);
@@ -130,6 +136,7 @@ public class Importer {
 			newLink.setNumberOfLanes(link.getNumberOfLanes());
 			newLink.setAllowedModes(link.getAllowedModes());
 			newLink.setOrigId(link.getId().toString());
+			newLink.setType(NetworkUtils.getType(link));
 			newLink.setSegments(Collections.singletonList(new WaySegment(way, 0)));
 			way2Links.put(way, Collections.singletonList(newLink));
 			linkId2Way.put(link.getId(), way);

--- a/src/main/java/org/matsim/contrib/josm/model/LinkConversionRules.java
+++ b/src/main/java/org/matsim/contrib/josm/model/LinkConversionRules.java
@@ -17,6 +17,7 @@ public class LinkConversionRules {
 	public static final String CAPACITY = "matsim:capacity";
 	public static final String MODES = "matsim:modes";
 	public static final String LENGTH = "matsim:length";
+	public static final String TYPE = "matsim:type";
 
 	static String getId(Way way, long increment, boolean backward) {
 		return String.valueOf(way.getUniqueId()) + "_" + increment + (backward ? "_r" : "");
@@ -155,6 +156,25 @@ public class LinkConversionRules {
 			}
 		}
 		return freespeed;
+	}
+
+
+	static String getType(Way way, OsmConvertDefaults.OsmWayDefaults defaults) {
+		String type = null;
+		if (way.getKeys().containsKey(TYPE)) {
+			type = way.getKeys().get(TYPE);
+		}
+		if (type == null) {
+			if (way.getKeys().containsKey("highway")) {
+				type = way.getKeys().get("highway");
+				Double freespeed = getFreespeed(way, defaults);
+				if (type != null && freespeed != null) {
+					type = String.format("%s_%d", type, Math.round(freespeed * 3.6));
+				}
+			}
+
+		}
+		return type;
 	}
 
 	static boolean isMatsimWay(Way way) {

--- a/src/main/java/org/matsim/contrib/josm/model/MLink.java
+++ b/src/main/java/org/matsim/contrib/josm/model/MLink.java
@@ -18,6 +18,7 @@ public class MLink {
 	private List<WaySegment> segments;
 	private MNode fromNode;
 	private MNode toNode;
+	private String type;
 
 	public MLink(MNode fromNode, MNode toNode) {
 
@@ -81,6 +82,15 @@ public class MLink {
 		return segments;
 	}
 
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public String getType() {
+		return type;
+	}
+
 	public Id<Link> getId() {
 		return Id.createLinkId(getOrigId());
 	}
@@ -100,4 +110,5 @@ public class MLink {
 	public void setReverseWayDirection(boolean reverseWayDirection) {
 		this.reverseWayDirection = reverseWayDirection;
 	}
+
 }

--- a/src/main/java/org/matsim/contrib/josm/model/NetworkModel.java
+++ b/src/main/java/org/matsim/contrib/josm/model/NetworkModel.java
@@ -317,6 +317,7 @@ public class NetworkModel {
 			final Double nofLanesPerDirection = LinkConversionRules.getLanesPerDirection(way, defaults, forward, backward);
 			final Double capacity = LinkConversionRules.getCapacity(way, defaults, nofLanesPerDirection);
 			final Set<String> modes = LinkConversionRules.getModes(way, defaults);
+			final String highwayType = LinkConversionRules.getType(way, defaults);
 
 			final Double taggedLength = LinkConversionRules.getTaggedLength(way);
 
@@ -361,6 +362,7 @@ public class NetworkModel {
 							l.setAllowedModes(modes);
 							l.setOrigId(origId);
 							l.setSegments(segs);
+							l.setType(highwayType);
 							links.add(l);
 						}
 						if (backward) {
@@ -374,6 +376,7 @@ public class NetworkModel {
 							l.setAllowedModes(modes);
 							l.setOrigId(origId);
 							l.setSegments(segs);
+							l.setType(highwayType);
 							l.setReverseWayDirection(true);
 							links.add(l);
 						}

--- a/src/main/resources/org/matsim/contrib/josm/matsimPreset.xml
+++ b/src/main/resources/org/matsim/contrib/josm/matsimPreset.xml
@@ -22,6 +22,7 @@
 			<space />
 			<optional>
 				<text key="matsim:length" text="length (estimated if not set)" default="" delete_if_empty="true" />
+				<text key="matsim:type" text="road service type" default="" delete_if_empty="true" />
 			</optional>
 		</item>
 	</group>


### PR DESCRIPTION
This is needed so that MATSim scenarios built on OSM networks can be used with the emissions module, which requires road type.

The format out the output is type_speed(kmh) (i.e. residential_30)

An option has been added to the preferences (Convertor tab) to turn this feature on or off.

The validation of the exported network has been extended to warn of links with no road type.