### PR TITLE
Update for compatibility with JOSM API >= 12881

### DIFF
--- a/src/main/java/org/matsim/contrib/josm/MATSimPlugin.java
+++ b/src/main/java/org/matsim/contrib/josm/MATSimPlugin.java
@@ -10,8 +10,8 @@ import org.matsim.contrib.josm.model.OsmConvertDefaults;
 import org.matsim.contrib.osm.*;
 import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.actions.ExtensionFileFilter;
-import org.openstreetmap.josm.data.Preferences.PreferenceChangeEvent;
-import org.openstreetmap.josm.data.Preferences.PreferenceChangedListener;
+import org.openstreetmap.josm.spi.preferences.PreferenceChangeEvent;
+import org.openstreetmap.josm.spi.preferences.PreferenceChangedListener;
 import org.openstreetmap.josm.data.osm.visitor.paint.MapRendererFactory;
 import org.openstreetmap.josm.data.validation.OsmValidator;
 import org.openstreetmap.josm.gui.MainApplication;
@@ -131,7 +131,7 @@ public class MATSimPlugin extends Plugin implements PreferenceChangedListener {
 		matsimTests.add(NetworkTest.class.getName());
 
 		//make sure MATSim Validators aren't executed before upload
-		Main.pref.putCollection(ValidatorPrefHelper.PREF_SKIP_TESTS_BEFORE_UPLOAD, matsimTests);
+		Config.getPref().putList(ValidatorPrefHelper.PREF_SKIP_TESTS_BEFORE_UPLOAD, matsimTests);
 	}
 
 	public void addDownloadSelection(List<DownloadSelection> list) {

--- a/src/main/java/org/matsim/contrib/josm/MATSimPlugin.java
+++ b/src/main/java/org/matsim/contrib/josm/MATSimPlugin.java
@@ -14,12 +14,12 @@ import org.openstreetmap.josm.data.Preferences.PreferenceChangeEvent;
 import org.openstreetmap.josm.data.Preferences.PreferenceChangedListener;
 import org.openstreetmap.josm.data.osm.visitor.paint.MapRendererFactory;
 import org.openstreetmap.josm.data.validation.OsmValidator;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.MainMenu;
 import org.openstreetmap.josm.gui.MapFrame;
 import org.openstreetmap.josm.gui.download.DownloadSelection;
 import org.openstreetmap.josm.gui.preferences.PreferenceSetting;
 import org.openstreetmap.josm.data.preferences.sources.ValidatorPrefHelper;
-import org.openstreetmap.josm.gui.tagging.ac.AutoCompletionManager;
 import org.openstreetmap.josm.gui.tagging.presets.TaggingPreset;
 import org.openstreetmap.josm.gui.tagging.presets.TaggingPresetMenu;
 import org.openstreetmap.josm.gui.tagging.presets.TaggingPresetReader;
@@ -57,7 +57,7 @@ public class MATSimPlugin extends Plugin implements PreferenceChangedListener {
 		// add xml exporter for matsim data
 		ExtensionFileFilter.addExporterFirst(new NetworkExporter());
 
-		MainMenu menu = Main.main.menu;
+		MainMenu menu = MainApplication.getMenu();
 
 		JMenu jMenu1 = menu.addMenu(marktr("OSM Repair"),marktr("OSM Repair") , KeyEvent.VK_CIRCUMFLEX, menu.getDefaultMenuPos(), "OSM Repair Tools");
 		jMenu1.add(new JMenuItem(new RepairAction("Create Master Routes", new MasterRoutesTest())));
@@ -88,13 +88,13 @@ public class MATSimPlugin extends Plugin implements PreferenceChangedListener {
 		}
 		for (TaggingPreset tp : tps) {
 			if (!(tp instanceof TaggingPresetSeparator)) {
-				Main.toolbar.register(tp);
+				MainApplication.getToolbar().register(tp);
 			}
 		}
 //		AutoCompletionManager.cachePresets(tps);
 		HashMap<TaggingPresetMenu, JMenu> submenus = new HashMap<>();
 		for (final TaggingPreset p : tps) {
-			JMenu m = p.group != null ? submenus.get(p.group) : Main.main.menu.presetsMenu;
+			JMenu m = p.group != null ? submenus.get(p.group) : MainApplication.getMenu().presetsMenu;
 			if (p instanceof TaggingPresetSeparator) {
 				m.add(new JSeparator());
 			} else if (p instanceof TaggingPresetMenu) {
@@ -140,12 +140,12 @@ public class MATSimPlugin extends Plugin implements PreferenceChangedListener {
 	@Override
 	public void mapFrameInitialized(MapFrame oldFrame, MapFrame newFrame) {
 		if (newFrame != null) {
-			Main.map.addToggleDialog(new LinksToggleDialog());
+			MainApplication.getMap().addToggleDialog(new LinksToggleDialog());
 			PTToggleDialog toggleDialog1 = new PTToggleDialog();
-			Main.map.addToggleDialog(toggleDialog1);
+			MainApplication.getMap().addToggleDialog(toggleDialog1);
 			toggleDialog1.init(); // after being added
 			StopAreasToggleDialog toggleDialog2 = new StopAreasToggleDialog();
-			Main.map.addToggleDialog(toggleDialog2);
+			MainApplication.getMap().addToggleDialog(toggleDialog2);
 			toggleDialog2.init(); // after being added
 		}
 	}

--- a/src/main/java/org/matsim/contrib/josm/MATSimPlugin.java
+++ b/src/main/java/org/matsim/contrib/josm/MATSimPlugin.java
@@ -26,6 +26,7 @@ import org.openstreetmap.josm.gui.tagging.presets.TaggingPresetReader;
 import org.openstreetmap.josm.gui.tagging.presets.TaggingPresetSeparator;
 import org.openstreetmap.josm.plugins.Plugin;
 import org.openstreetmap.josm.plugins.PluginInformation;
+import org.openstreetmap.josm.spi.preferences.Config;
 import org.xml.sax.SAXException;
 
 import javax.swing.*;
@@ -120,7 +121,7 @@ public class MATSimPlugin extends Plugin implements PreferenceChangedListener {
 		// register for preference changed events
 		Main.pref.addPreferenceChangeListener(this);
 		Main.pref.addPreferenceChangeListener(MapRenderer.PROPERTIES);
-		OsmConvertDefaults.listen(Main.pref);
+		OsmConvertDefaults.listen(Config.getPref());
 
 		// load default converting parameters
 
@@ -128,7 +129,7 @@ public class MATSimPlugin extends Plugin implements PreferenceChangedListener {
 		List<String> matsimTests = new ArrayList<>();
 		OsmValidator.addTest(NetworkTest.class);
 		matsimTests.add(NetworkTest.class.getName());
-		
+
 		//make sure MATSim Validators aren't executed before upload
 		Main.pref.putCollection(ValidatorPrefHelper.PREF_SKIP_TESTS_BEFORE_UPLOAD, matsimTests);
 	}

--- a/src/main/java/org/matsim/contrib/josm/MATSimPlugin.java
+++ b/src/main/java/org/matsim/contrib/josm/MATSimPlugin.java
@@ -8,7 +8,6 @@ import org.matsim.contrib.josm.gui.StopAreasToggleDialog;
 import org.matsim.contrib.josm.gui.Preferences;
 import org.matsim.contrib.josm.model.OsmConvertDefaults;
 import org.matsim.contrib.osm.*;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.actions.ExtensionFileFilter;
 import org.openstreetmap.josm.spi.preferences.PreferenceChangeEvent;
 import org.openstreetmap.josm.spi.preferences.PreferenceChangedListener;
@@ -19,6 +18,7 @@ import org.openstreetmap.josm.gui.MainMenu;
 import org.openstreetmap.josm.gui.MapFrame;
 import org.openstreetmap.josm.gui.download.DownloadSelection;
 import org.openstreetmap.josm.gui.preferences.PreferenceSetting;
+import org.openstreetmap.josm.data.preferences.BooleanProperty;
 import org.openstreetmap.josm.data.preferences.sources.ValidatorPrefHelper;
 import org.openstreetmap.josm.gui.tagging.presets.TaggingPreset;
 import org.openstreetmap.josm.gui.tagging.presets.TaggingPresetMenu;
@@ -75,7 +75,7 @@ public class MATSimPlugin extends Plugin implements PreferenceChangedListener {
 		jMenu2.add(new JSeparator());
 		jMenu2.add(new RepairAction("Validate TransitSchedule", new TransitScheduleTest()));
 		TransitScheduleExportAction transitScheduleExportAction = new TransitScheduleExportAction();
-		Main.pref.addPreferenceChangeListener(transitScheduleExportAction);
+		Config.getPref().addPreferenceChangeListener(transitScheduleExportAction);
 		jMenu2.add(transitScheduleExportAction);
 		jMenu2.add(new OTFVisAction());
 
@@ -112,15 +112,14 @@ public class MATSimPlugin extends Plugin implements PreferenceChangedListener {
 		}
 
 		// register map renderer
-		if (Main.pref.getBoolean("matsim_renderer", false)) {
+		if (new BooleanProperty("matsim_renderer", false).get()) {
 			MapRendererFactory factory = MapRendererFactory.getInstance();
 			factory.register(MapRenderer.class, "MATSim Renderer", "This is the MATSim map renderer");
 			factory.activate(MapRenderer.class);
 		}
 
 		// register for preference changed events
-		Main.pref.addPreferenceChangeListener(this);
-		Main.pref.addPreferenceChangeListener(MapRenderer.PROPERTIES);
+		Config.getPref().addPreferenceChangeListener(this);
 		OsmConvertDefaults.listen(Config.getPref());
 
 		// load default converting parameters
@@ -160,7 +159,7 @@ public class MATSimPlugin extends Plugin implements PreferenceChangedListener {
 	public void preferenceChanged(PreferenceChangeEvent e) {
 		if (e.getKey().equalsIgnoreCase("matsim_renderer")) {
 			MapRendererFactory factory = MapRendererFactory.getInstance();
-			if (Main.pref.getBoolean("matsim_renderer")) {
+			if (new BooleanProperty("matsim_renderer", false).get()) {
 				factory.register(MapRenderer.class, "MATSim Renderer", "This is the MATSim map renderer");
 				factory.activate(MapRenderer.class);
 			} else {

--- a/src/main/java/org/matsim/contrib/josm/MapRenderer.java
+++ b/src/main/java/org/matsim/contrib/josm/MapRenderer.java
@@ -3,18 +3,17 @@ package org.matsim.contrib.josm;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contrib.josm.model.MLink;
 import org.matsim.contrib.josm.model.OsmConvertDefaults;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.data.osm.OsmPrimitive;
 import org.openstreetmap.josm.data.osm.Way;
 import org.openstreetmap.josm.data.osm.visitor.paint.MapRendererFactory;
 import org.openstreetmap.josm.data.osm.visitor.paint.StyledMapRenderer;
+import org.openstreetmap.josm.data.preferences.BooleanProperty;
+import org.openstreetmap.josm.data.preferences.DoubleProperty;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.NavigatableComponent;
 import org.openstreetmap.josm.gui.mappaint.styleelement.LabelCompositionStrategy;
 import org.openstreetmap.josm.gui.mappaint.styleelement.TextLabel;
 import org.openstreetmap.josm.gui.mappaint.styleelement.placement.OnLineStrategy;
-import org.openstreetmap.josm.spi.preferences.PreferenceChangeEvent;
-import org.openstreetmap.josm.spi.preferences.PreferenceChangedListener;
 
 import java.awt.*;
 import java.util.HashMap;
@@ -72,8 +71,8 @@ public class MapRenderer extends StyledMapRenderer {
 
         if (way2Links != null && way2Links.containsKey(way) && !way2Links.get(way).isEmpty()) {
             if (!way.isSelected()) {
-                if (Properties.showIds) { // draw id on path
-                    TextLabel label = new MATSimTextLabel(PROPERTIES, PROPERTIES.FONT, Properties.MATSIMCOLOR, 0.f, new Color(0, 145, 190));
+                if (Properties.SHOW_IDS.get()) { // draw id on path
+                    TextLabel label = new MATSimTextLabel(PROPERTIES, Properties.FONT, Properties.MATSIMCOLOR, 0.f, new Color(0, 145, 190));
                     drawText(way, label, new OnLineStrategy(textOffset(way)));
                 }
                 if (way.hasTag("modes", TransportMode.pt)) { // draw
@@ -84,24 +83,24 @@ public class MapRenderer extends StyledMapRenderer {
                     // links
                     float[] dashPhase = {9.f};
                     BasicStroke trainDashes = new BasicStroke(2, 0, 1, 10.f, dashPhase, 9.f);
-                    super.drawWay(way, Properties.MATSIMCOLOR, line, trainDashes, Color.white, Properties.wayOffset * -1, showOrientation,
+                    super.drawWay(way, Properties.MATSIMCOLOR, line, trainDashes, Color.white, Properties.WAY_OFFSET.get().floatValue() * -1, showOrientation,
                             showHeadArrowOnly, !way.hasTag("highway", OsmConvertDefaults.getWayDefaults().keySet()), onewayReversed);
                 } else { // draw simple blue lines for other links, if
                     // way is not converted by highway tag, draw
                     // direction arrow for directed edge
-                    super.drawWay(way, Properties.MATSIMCOLOR, line, dashes, dashedColor, Properties.wayOffset * -1, showOrientation,
+                    super.drawWay(way, Properties.MATSIMCOLOR, line, dashes, dashedColor, Properties.WAY_OFFSET.get().floatValue() * -1, showOrientation,
                             showHeadArrowOnly, !way.hasTag("highway", OsmConvertDefaults.getWayDefaults().keySet()), onewayReversed);
                 }
                 return;
             } else {
-                if (Properties.showIds) { // draw ids on selected ways
+                if (Properties.SHOW_IDS.get()) { // draw ids on selected ways
                     // also
                     TextLabel label = new MATSimTextLabel(PROPERTIES, PROPERTIES.FONT, selectedColor, 0.f, selectedColor);
                     drawText(way, label, new OnLineStrategy(textOffset(way)));
                 }
             }
         }
-        super.drawWay(way, color, line, dashes, dashedColor, Properties.wayOffset * -1, showOrientation, showHeadArrowOnly, showOneway,
+        super.drawWay(way, color, line, dashes, dashedColor, Properties.WAY_OFFSET.get().floatValue() * -1, showOrientation, showHeadArrowOnly, showOneway,
                 onewayReversed);
     }
 
@@ -129,23 +128,12 @@ public class MapRenderer extends StyledMapRenderer {
      *
      * @author Nico
      */
-    static class Properties implements PreferenceChangedListener, LabelCompositionStrategy {
+    static class Properties implements LabelCompositionStrategy {
 
         final static Font FONT = new Font("Droid Sans", Font.PLAIN, 14);
         final static Color MATSIMCOLOR = new Color(80, 145, 190);
-        static boolean showIds = Main.pref.getBoolean("matsim_showIds", false);
-        static float wayOffset = ((float) Main.pref.getDouble("matsim_wayOffset", 0));
-
-        @Override
-        // listen for changes in preferences that concern renderer adjustments
-        public void preferenceChanged(PreferenceChangeEvent e) {
-            if (e.getKey().equalsIgnoreCase("matsim_showIds")) {
-                showIds = Main.pref.getBoolean("matsim_showIds");
-            }
-            if (e.getKey().equalsIgnoreCase("matsim_wayOffset")) {
-                wayOffset = ((float) (Main.pref.getDouble("matsim_wayOffset", 0)));
-            }
-        }
+        final static BooleanProperty SHOW_IDS = new BooleanProperty("matsim_showIds", false);
+        final static DoubleProperty WAY_OFFSET = new DoubleProperty("matsim_wayOffset", 0);
 
         /**
          * Composes the MATSim Id text for the OsmPrimitive <code>prim</code>.

--- a/src/main/java/org/matsim/contrib/josm/MapRenderer.java
+++ b/src/main/java/org/matsim/contrib/josm/MapRenderer.java
@@ -10,6 +10,7 @@ import org.openstreetmap.josm.data.osm.OsmPrimitive;
 import org.openstreetmap.josm.data.osm.Way;
 import org.openstreetmap.josm.data.osm.visitor.paint.MapRendererFactory;
 import org.openstreetmap.josm.data.osm.visitor.paint.StyledMapRenderer;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.NavigatableComponent;
 import org.openstreetmap.josm.gui.mappaint.styleelement.LabelCompositionStrategy;
 import org.openstreetmap.josm.gui.mappaint.styleelement.TextLabel;
@@ -49,7 +50,7 @@ public class MapRenderer extends StyledMapRenderer {
 
     public static void setWay2Links(Map<Way, List<MLink>> way2LinksTmp) {
         way2Links = way2LinksTmp;
-        Main.map.repaint();
+        MainApplication.getMap().repaint();
     }
 
     /**

--- a/src/main/java/org/matsim/contrib/josm/MapRenderer.java
+++ b/src/main/java/org/matsim/contrib/josm/MapRenderer.java
@@ -4,8 +4,6 @@ import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contrib.josm.model.MLink;
 import org.matsim.contrib.josm.model.OsmConvertDefaults;
 import org.openstreetmap.josm.Main;
-import org.openstreetmap.josm.data.Preferences.PreferenceChangeEvent;
-import org.openstreetmap.josm.data.Preferences.PreferenceChangedListener;
 import org.openstreetmap.josm.data.osm.OsmPrimitive;
 import org.openstreetmap.josm.data.osm.Way;
 import org.openstreetmap.josm.data.osm.visitor.paint.MapRendererFactory;
@@ -15,6 +13,8 @@ import org.openstreetmap.josm.gui.NavigatableComponent;
 import org.openstreetmap.josm.gui.mappaint.styleelement.LabelCompositionStrategy;
 import org.openstreetmap.josm.gui.mappaint.styleelement.TextLabel;
 import org.openstreetmap.josm.gui.mappaint.styleelement.placement.OnLineStrategy;
+import org.openstreetmap.josm.spi.preferences.PreferenceChangeEvent;
+import org.openstreetmap.josm.spi.preferences.PreferenceChangedListener;
 
 import java.awt.*;
 import java.util.HashMap;

--- a/src/main/java/org/matsim/contrib/josm/actions/ConvertAction.java
+++ b/src/main/java/org/matsim/contrib/josm/actions/ConvertAction.java
@@ -4,10 +4,10 @@ import org.matsim.contrib.josm.model.LayerConverter;
 import org.matsim.contrib.josm.model.MATSimLayer;
 import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.actions.JosmAction;
-import org.openstreetmap.josm.data.ProjectionBounds;
 import org.openstreetmap.josm.data.validation.OsmValidator;
 import org.openstreetmap.josm.data.validation.Severity;
 import org.openstreetmap.josm.data.validation.TestError;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.PleaseWaitRunnable;
 import org.openstreetmap.josm.gui.progress.swing.PleaseWaitProgressMonitor;
 import org.openstreetmap.josm.io.OsmTransferException;
@@ -54,9 +54,9 @@ public class ConvertAction extends JosmAction {
 				@Override
 				protected void realRun() throws SAXException, IOException, OsmTransferException {
 					if (Main.pref.getBoolean("matsim_transit_lite")) {
-						this.layer = LayerConverter.convertToPseudoNetwork(Main.getLayerManager().getEditLayer());
+						this.layer = LayerConverter.convertToPseudoNetwork(MainApplication.getLayerManager().getEditLayer());
 					} else {
-						this.layer = LayerConverter.convertWithFullTransit(Main.getLayerManager().getEditLayer());
+						this.layer = LayerConverter.convertWithFullTransit(MainApplication.getLayerManager().getEditLayer());
 					}
 				}
 
@@ -67,17 +67,17 @@ public class ConvertAction extends JosmAction {
 						// it is.
 						// (Perhaps I want to look at the particular are I am viewing right
 						// now.)
-						Main.getLayerManager().addLayer(layer);
+						MainApplication.getLayerManager().addLayer(layer);
 					}
 				}
 			};
 			task.run();
 		} else {
 			OsmValidator.initializeErrorLayer();
-			Main.map.validatorDialog.unfurlDialog();
-			Main.getLayerManager().getEditLayer().validationErrors.clear();
-			Main.getLayerManager().getEditLayer().validationErrors.addAll(breakingErrors);
-			Main.map.validatorDialog.tree.setErrors(breakingErrors);
+			MainApplication.getMap().validatorDialog.unfurlDialog();
+			MainApplication.getLayerManager().getEditLayer().validationErrors.clear();
+			MainApplication.getLayerManager().getEditLayer().validationErrors.addAll(breakingErrors);
+			MainApplication.getMap().validatorDialog.tree.setErrors(breakingErrors);
 		}
     }
 
@@ -85,7 +85,7 @@ public class ConvertAction extends JosmAction {
 		NetworkTest test1 = new NetworkTest();
 		PleaseWaitProgressMonitor progMonitor1 = new PleaseWaitProgressMonitor("Validation");
 		test1.startTest(progMonitor1);
-		test1.visit(Main.getLayerManager().getEditDataSet().allPrimitives());
+		test1.visit(MainApplication.getLayerManager().getEditDataSet().allPrimitives());
 		test1.endTest();
 		progMonitor1.finishTask();
 		progMonitor1.close();
@@ -99,7 +99,7 @@ public class ConvertAction extends JosmAction {
 		TransitScheduleTest test2 = new TransitScheduleTest();
 		PleaseWaitProgressMonitor progMonitor2 = new PleaseWaitProgressMonitor("Validation");
 		test2.startTest(progMonitor2);
-		test2.visit(Main.getLayerManager().getEditDataSet().allPrimitives());
+		test2.visit(MainApplication.getLayerManager().getEditDataSet().allPrimitives());
 		test2.endTest();
 		progMonitor2.finishTask();
 		progMonitor2.close();
@@ -116,7 +116,7 @@ public class ConvertAction extends JosmAction {
 
 	@Override
     protected void updateEnabledState() {
-        setEnabled(Main.getLayerManager().getEditLayer() != null && !(Main.getLayerManager().getEditLayer() instanceof MATSimLayer));
+        setEnabled(MainApplication.getLayerManager().getEditLayer() != null && !(MainApplication.getLayerManager().getEditLayer() instanceof MATSimLayer));
     }
 
 }

--- a/src/main/java/org/matsim/contrib/josm/actions/ConvertAction.java
+++ b/src/main/java/org/matsim/contrib/josm/actions/ConvertAction.java
@@ -1,5 +1,6 @@
 package org.matsim.contrib.josm.actions;
 
+import org.matsim.contrib.josm.gui.Preferences;
 import org.matsim.contrib.josm.model.LayerConverter;
 import org.matsim.contrib.josm.model.MATSimLayer;
 import org.openstreetmap.josm.Main;
@@ -53,7 +54,7 @@ public class ConvertAction extends JosmAction {
 
 				@Override
 				protected void realRun() throws SAXException, IOException, OsmTransferException {
-					if (Main.pref.getBoolean("matsim_transit_lite")) {
+					if (Preferences.isTransitLite()) {
 						this.layer = LayerConverter.convertToPseudoNetwork(MainApplication.getLayerManager().getEditLayer());
 					} else {
 						this.layer = LayerConverter.convertWithFullTransit(MainApplication.getLayerManager().getEditLayer());
@@ -89,13 +90,13 @@ public class ConvertAction extends JosmAction {
 		test1.endTest();
 		progMonitor1.finishTask();
 		progMonitor1.close();
-		
+
 		if (test1.getErrors().stream().anyMatch(error -> error.getSeverity().equals(Severity.ERROR))) {
 			JOptionPane.showMessageDialog(Main.parent, "Export failed due to validation errors. See validation layer for details.",
 					"Failure", JOptionPane.ERROR_MESSAGE, new ImageProvider("warning-small").setWidth(16).get());
 			return test1.getErrors();
-		} 
-		
+		}
+
 		TransitScheduleTest test2 = new TransitScheduleTest();
 		PleaseWaitProgressMonitor progMonitor2 = new PleaseWaitProgressMonitor("Validation");
 		test2.startTest(progMonitor2);

--- a/src/main/java/org/matsim/contrib/josm/actions/DownloadAction.java
+++ b/src/main/java/org/matsim/contrib/josm/actions/DownloadAction.java
@@ -2,12 +2,12 @@ package org.matsim.contrib.josm.actions;
 
 import org.matsim.contrib.josm.gui.DownloadDialog;
 import org.matsim.contrib.josm.model.OsmConvertDefaults;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.actions.JosmAction;
 import org.openstreetmap.josm.actions.downloadtasks.DownloadOsmTask;
 import org.openstreetmap.josm.actions.downloadtasks.PostDownloadHandler;
 import org.openstreetmap.josm.data.Bounds;
 import org.openstreetmap.josm.data.osm.DataSet;
+import org.openstreetmap.josm.data.preferences.BooleanProperty;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.progress.ProgressMonitor;
 import org.openstreetmap.josm.io.OsmReader;
@@ -141,7 +141,7 @@ public class DownloadAction extends JosmAction {
 			int counter = 0;
 			StringBuilder routes = new StringBuilder("[\"route\"~\"");
 			for (String route : OsmConvertDefaults.routeTypes) {
-				if (Main.pref.getBoolean("matsim_download_" + route, true)) {
+				if (new BooleanProperty("matsim_download_" + route, true).get()) {
 					routes.append(route);
 					routes.append("|");
 					counter++;
@@ -162,7 +162,7 @@ public class DownloadAction extends JosmAction {
 			int counter = 0;
 			StringBuilder highways = new StringBuilder("[\"highway\"~\"");
 			for (String highway : OsmConvertDefaults.highwayTypes) {
-				if (Main.pref.getBoolean("matsim_download_" + highway, true)) {
+				if (new BooleanProperty("matsim_download_" + highway, true).get()) {
 					highways.append(highway);
 					highways.append("|");
 					counter++;

--- a/src/main/java/org/matsim/contrib/josm/actions/DownloadAction.java
+++ b/src/main/java/org/matsim/contrib/josm/actions/DownloadAction.java
@@ -8,6 +8,7 @@ import org.openstreetmap.josm.actions.downloadtasks.DownloadOsmTask;
 import org.openstreetmap.josm.actions.downloadtasks.PostDownloadHandler;
 import org.openstreetmap.josm.data.Bounds;
 import org.openstreetmap.josm.data.osm.DataSet;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.progress.ProgressMonitor;
 import org.openstreetmap.josm.io.OsmReader;
 import org.openstreetmap.josm.io.OsmServerReader;
@@ -46,7 +47,7 @@ public class DownloadAction extends JosmAction {
 			dialog.rememberSettings();
 			Bounds area = dialog.getSelectedDownloadArea().get();
 			DownloadOsmTask task = new DownloadOsmTask();
-			Main.worker.submit(new PostDownloadHandler(task, task.download(new FilteredDownloader(area), dialog.isNewLayerRequired(), area, null)));
+			MainApplication.worker.submit(new PostDownloadHandler(task, task.download(new FilteredDownloader(area), dialog.isNewLayerRequired(), area, null)));
 		}
 	}
 

--- a/src/main/java/org/matsim/contrib/josm/actions/DownloadVBBAction.java
+++ b/src/main/java/org/matsim/contrib/josm/actions/DownloadVBBAction.java
@@ -1,10 +1,10 @@
 package org.matsim.contrib.josm.actions;
 
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.actions.JosmAction;
 import org.openstreetmap.josm.actions.downloadtasks.DownloadOsmTask;
 import org.openstreetmap.josm.actions.downloadtasks.PostDownloadHandler;
 import org.openstreetmap.josm.data.Bounds;
+import org.openstreetmap.josm.gui.MainApplication;
 
 import java.awt.event.ActionEvent;
 
@@ -33,7 +33,7 @@ public class DownloadVBBAction extends JosmAction {
 				String.format("[timeout:%d];", MyOverpassDownloader.TIMEOUT_S) +
 				"rel[\"type\"=\"route_master\"][\"network\"=\"Verkehrsverbund Berlin-Brandenburg\"];" +
 				"out meta;";
-		Main.worker.submit(new PostDownloadHandler(task, task.download(new MyOverpassDownloader(query) ,true, new Bounds(0,0,true), null)));
+		MainApplication.worker.submit(new PostDownloadHandler(task, task.download(new MyOverpassDownloader(query) ,true, new Bounds(0,0,true), null)));
 	}
 
 }

--- a/src/main/java/org/matsim/contrib/josm/actions/ImportAction.java
+++ b/src/main/java/org/matsim/contrib/josm/actions/ImportAction.java
@@ -5,6 +5,7 @@ import org.matsim.contrib.josm.model.Importer;
 import org.matsim.contrib.josm.model.MATSimLayer;
 import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.actions.JosmAction;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.PleaseWaitRunnable;
 import org.openstreetmap.josm.gui.preferences.projection.ProjectionChoice;
 import org.openstreetmap.josm.gui.preferences.projection.ProjectionPreference;
@@ -64,8 +65,8 @@ public class ImportAction extends JosmAction {
                             // layer = null happens if Exception happens during import,
                             // as Exceptions are handled only after this method is called.
                             if (layer != null) {
-                                Main.getLayerManager().addLayer(layer);
-                                Main.getLayerManager().setActiveLayer(layer);
+                                MainApplication.getLayerManager().addLayer(layer);
+                                MainApplication.getLayerManager().setActiveLayer(layer);
                             }
                         }
 
@@ -78,7 +79,7 @@ public class ImportAction extends JosmAction {
                             }
                         }
                     };
-                    Main.worker.execute(task);
+                    MainApplication.worker.execute(task);
                 }
             }
         }

--- a/src/main/java/org/matsim/contrib/josm/actions/NetworkExporter.java
+++ b/src/main/java/org/matsim/contrib/josm/actions/NetworkExporter.java
@@ -19,6 +19,7 @@ import org.openstreetmap.josm.data.validation.TestError;
 import org.openstreetmap.josm.gui.layer.Layer;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
 import org.openstreetmap.josm.gui.progress.swing.PleaseWaitProgressMonitor;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.io.importexport.FileExporter;
 import org.openstreetmap.josm.tools.ImageProvider;
 
@@ -126,10 +127,10 @@ public final class NetworkExporter extends FileExporter {
 
 		// set up error layer
 		OsmValidator.initializeErrorLayer();
-		Main.map.validatorDialog.unfurlDialog();
-		Main.getLayerManager().getEditLayer().validationErrors.clear();
-		Main.getLayerManager().getEditLayer().validationErrors.addAll(test.getErrors());
-		Main.map.validatorDialog.tree.setErrors(test.getErrors());
+		MainApplication.getMap().validatorDialog.unfurlDialog();
+		MainApplication.getLayerManager().getEditLayer().validationErrors.clear();
+		MainApplication.getLayerManager().getEditLayer().validationErrors.addAll(test.getErrors());
+		MainApplication.getMap().validatorDialog.tree.setErrors(test.getErrors());
 
 	}
 }

--- a/src/main/java/org/matsim/contrib/josm/actions/NetworkExporter.java
+++ b/src/main/java/org/matsim/contrib/josm/actions/NetworkExporter.java
@@ -115,7 +115,7 @@ public final class NetworkExporter extends FileExporter {
 		if (okToExport) {
 			Scenario targetScenario = Export.toScenario(((MATSimLayer) layer).getNetworkModel());
 
-			if (Main.pref.getBoolean("matsim_cleanNetwork")) {
+			if (Preferences.PROP_CLEAN_NETWORK.get()) {
 				new NetworkCleaner().run(targetScenario.getNetwork());
 			}
 			if(Preferences.getNetworkExportVersion().equals("v1")) {

--- a/src/main/java/org/matsim/contrib/josm/actions/NetworkTest.java
+++ b/src/main/java/org/matsim/contrib/josm/actions/NetworkTest.java
@@ -17,7 +17,6 @@ import org.matsim.contrib.josm.model.MNode;
 import org.matsim.contrib.josm.model.NetworkModel;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.command.ChangePropertyCommand;
 import org.openstreetmap.josm.command.Command;
 import org.openstreetmap.josm.command.SequenceCommand;
@@ -28,6 +27,7 @@ import org.openstreetmap.josm.data.osm.WaySegment;
 import org.openstreetmap.josm.data.validation.Severity;
 import org.openstreetmap.josm.data.validation.Test;
 import org.openstreetmap.josm.data.validation.TestError;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.progress.ProgressMonitor;
 
 /**
@@ -83,12 +83,12 @@ public class NetworkTest extends Test {
 	public void startTest(ProgressMonitor monitor) {
 		this.nodeIds = new HashMap<>();
 		this.linkIds = new HashMap<>();
-		if (Main.getLayerManager().getActiveLayer() instanceof MATSimLayer) {
-			this.networkModel = ((MATSimLayer) Main.getLayerManager().getActiveLayer()).getNetworkModel();
+		if (MainApplication.getLayerManager().getActiveLayer() instanceof MATSimLayer) {
+			this.networkModel = ((MATSimLayer) MainApplication.getLayerManager().getActiveLayer()).getNetworkModel();
 		} else {
 			Config config = ConfigUtils.createConfig();
 			config.transit().setUseTransit(true);
-			NetworkModel networkModel = NetworkModel.createNetworkModel(Main.getLayerManager().getEditDataSet());
+			NetworkModel networkModel = NetworkModel.createNetworkModel(MainApplication.getLayerManager().getEditDataSet());
 			networkModel.visitAll();
 			this.networkModel = networkModel;
 		}

--- a/src/main/java/org/matsim/contrib/josm/actions/NewNetworkAction.java
+++ b/src/main/java/org/matsim/contrib/josm/actions/NewNetworkAction.java
@@ -2,9 +2,9 @@ package org.matsim.contrib.josm.actions;
 
 import org.matsim.contrib.josm.model.MATSimLayer;
 import org.matsim.contrib.josm.model.NetworkModel;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.actions.JosmAction;
 import org.openstreetmap.josm.data.osm.DataSet;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.tools.Shortcut;
 
 import java.awt.event.ActionEvent;
@@ -29,7 +29,7 @@ public class NewNetworkAction extends JosmAction {
 
 	@Override
 	public void actionPerformed(ActionEvent e) {
-		Main.getLayerManager().addLayer(createMatsimLayer());
+		MainApplication.getLayerManager().addLayer(createMatsimLayer());
 	}
 
 	public static MATSimLayer createMatsimLayer() {

--- a/src/main/java/org/matsim/contrib/josm/actions/OTFVisAction.java
+++ b/src/main/java/org/matsim/contrib/josm/actions/OTFVisAction.java
@@ -17,8 +17,8 @@ import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
 import org.matsim.pt.utils.CreateVehiclesForSchedule;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.actions.JosmAction;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.tools.Shortcut;
 
 import java.awt.event.ActionEvent;
@@ -35,7 +35,7 @@ public class OTFVisAction extends JosmAction {
 
 	@Override
 	public void actionPerformed(ActionEvent e) {
-		NetworkModel networkModel = NetworkModel.createNetworkModel(Main.getLayerManager().getEditDataSet());
+		NetworkModel networkModel = NetworkModel.createNetworkModel(MainApplication.getLayerManager().getEditDataSet());
 		networkModel.visitAll();
 		Scenario scenario = Export.toScenario(networkModel);
 

--- a/src/main/java/org/matsim/contrib/josm/actions/TransitScheduleExportAction.java
+++ b/src/main/java/org/matsim/contrib/josm/actions/TransitScheduleExportAction.java
@@ -14,6 +14,8 @@ import org.openstreetmap.josm.data.validation.Severity;
 import org.openstreetmap.josm.data.validation.TestError;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.progress.swing.PleaseWaitProgressMonitor;
+import org.openstreetmap.josm.spi.preferences.PreferenceChangeEvent;
+import org.openstreetmap.josm.spi.preferences.PreferenceChangedListener;
 import org.openstreetmap.josm.tools.ImageProvider;
 
 import javax.swing.*;
@@ -23,7 +25,7 @@ import java.io.File;
 import static org.openstreetmap.josm.actions.SaveActionBase.createAndOpenSaveFileChooser;
 import static org.openstreetmap.josm.tools.I18n.tr;
 
-public class TransitScheduleExportAction extends DiskAccessAction implements org.openstreetmap.josm.data.Preferences.PreferenceChangedListener {
+public class TransitScheduleExportAction extends DiskAccessAction implements PreferenceChangedListener {
 
 	public TransitScheduleExportAction() {
 		super(tr("Export MATSim transit schedule..."), null, tr("Export the transit schedule."), null);
@@ -102,7 +104,7 @@ public class TransitScheduleExportAction extends DiskAccessAction implements org
 	}
 
 	@Override
-	public void preferenceChanged(org.openstreetmap.josm.data.Preferences.PreferenceChangeEvent preferenceChangeEvent) {
+	public void preferenceChanged(PreferenceChangeEvent preferenceChangeEvent) {
 		setEnabled(shouldBeEnabled());
 	}
 

--- a/src/main/java/org/matsim/contrib/josm/actions/TransitScheduleExportAction.java
+++ b/src/main/java/org/matsim/contrib/josm/actions/TransitScheduleExportAction.java
@@ -12,6 +12,7 @@ import org.openstreetmap.josm.actions.ExtensionFileFilter;
 import org.openstreetmap.josm.data.validation.OsmValidator;
 import org.openstreetmap.josm.data.validation.Severity;
 import org.openstreetmap.josm.data.validation.TestError;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.progress.swing.PleaseWaitProgressMonitor;
 import org.openstreetmap.josm.tools.ImageProvider;
 
@@ -40,7 +41,7 @@ public class TransitScheduleExportAction extends DiskAccessAction implements org
 
 				// convertWithFullTransit validator tests
 				test.startTest(progMonitor);
-				test.visit(Main.getLayerManager().getEditDataSet().allPrimitives());
+				test.visit(MainApplication.getLayerManager().getEditDataSet().allPrimitives());
 				test.endTest();
 				progMonitor.finishTask();
 				progMonitor.close();
@@ -74,16 +75,16 @@ public class TransitScheduleExportAction extends DiskAccessAction implements org
 
 				// start export task if not aborted
 				if (okToExport) {
-					Scenario targetScenario = Export.toScenario(((MATSimLayer) Main.getLayerManager().getActiveLayer()).getNetworkModel());
+					Scenario targetScenario = Export.toScenario(((MATSimLayer) MainApplication.getLayerManager().getActiveLayer()).getNetworkModel());
 					new TransitScheduleWriter(targetScenario.getTransitSchedule()).writeFile(file.getPath());
 				}
 
 				// set up error layer
 				OsmValidator.initializeErrorLayer();
-				Main.map.validatorDialog.unfurlDialog();
-				Main.getLayerManager().getEditLayer().validationErrors.clear();
-				Main.getLayerManager().getEditLayer().validationErrors.addAll(test.getErrors());
-				Main.map.validatorDialog.tree.setErrors(test.getErrors());
+				MainApplication.getMap().validatorDialog.unfurlDialog();
+				MainApplication.getLayerManager().getEditLayer().validationErrors.clear();
+				MainApplication.getLayerManager().getEditLayer().validationErrors.addAll(test.getErrors());
+				MainApplication.getMap().validatorDialog.tree.setErrors(test.getErrors());
 
 			}
 		} else {

--- a/src/main/java/org/matsim/contrib/josm/actions/TransitScheduleTest.java
+++ b/src/main/java/org/matsim/contrib/josm/actions/TransitScheduleTest.java
@@ -9,8 +9,6 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.Scenario;
-import org.matsim.contrib.josm.model.Export;
 import org.matsim.contrib.josm.model.Line;
 import org.matsim.contrib.josm.model.MATSimLayer;
 import org.matsim.contrib.josm.model.NetworkModel;
@@ -21,9 +19,6 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
-import org.matsim.pt.utils.TransitScheduleValidator;
-import org.matsim.pt.utils.TransitScheduleValidator.ValidationResult;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.command.ChangePropertyCommand;
 import org.openstreetmap.josm.command.Command;
 import org.openstreetmap.josm.command.SequenceCommand;
@@ -31,6 +26,7 @@ import org.openstreetmap.josm.data.osm.OsmPrimitive;
 import org.openstreetmap.josm.data.validation.Severity;
 import org.openstreetmap.josm.data.validation.Test;
 import org.openstreetmap.josm.data.validation.TestError;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.progress.ProgressMonitor;
 
 public class TransitScheduleTest extends Test {
@@ -64,12 +60,12 @@ public class TransitScheduleTest extends Test {
 	 */
 	@Override
 	public void startTest(ProgressMonitor monitor) {
-		if (Main.getLayerManager().getActiveLayer() instanceof MATSimLayer) {
-			this.networkModel = ((MATSimLayer) Main.getLayerManager().getActiveLayer()).getNetworkModel();
+		if (MainApplication.getLayerManager().getActiveLayer() instanceof MATSimLayer) {
+			this.networkModel = ((MATSimLayer) MainApplication.getLayerManager().getActiveLayer()).getNetworkModel();
 		} else {
 			Config config = ConfigUtils.createConfig();
 			config.transit().setUseTransit(true);
-			NetworkModel networkModel = NetworkModel.createNetworkModel(Main.getLayerManager().getEditDataSet());
+			NetworkModel networkModel = NetworkModel.createNetworkModel(MainApplication.getLayerManager().getEditDataSet());
 			networkModel.visitAll();
 			this.networkModel = networkModel;
 		}

--- a/src/main/java/org/matsim/contrib/josm/gui/DownloadDialog.java
+++ b/src/main/java/org/matsim/contrib/josm/gui/DownloadDialog.java
@@ -2,6 +2,7 @@ package org.matsim.contrib.josm.gui;
 
 import org.matsim.contrib.josm.model.OsmConvertDefaults;
 import org.openstreetmap.josm.Main;
+import org.openstreetmap.josm.spi.preferences.Config;
 import org.openstreetmap.josm.tools.GBC;
 
 import javax.swing.*;
@@ -28,7 +29,7 @@ public class DownloadDialog extends org.openstreetmap.josm.gui.download.Download
 
 		ActionListener cbListener = e -> {
 			JCheckBox cb = (JCheckBox) e.getSource();
-			Main.pref.put("matsim_download_" + cb.getText(), cb.isSelected());
+			Config.getPref().putBoolean("matsim_download_" + cb.getText(), cb.isSelected());
 		};
 
 		JPanel highwaysPnl = new JPanel(new FlowLayout());

--- a/src/main/java/org/matsim/contrib/josm/gui/DownloadDialog.java
+++ b/src/main/java/org/matsim/contrib/josm/gui/DownloadDialog.java
@@ -37,7 +37,7 @@ public class DownloadDialog extends org.openstreetmap.josm.gui.download.Download
 		for (String highwayType : OsmConvertDefaults.highwayTypes) {
 			JCheckBox cb = new JCheckBox(highwayType);
 			cb.setToolTipText(tr("Select to download " + cb.getText() + " highways in the selected download area."));
-			cb.setSelected(Main.pref.getBoolean("matsim_download_" + cb.getText(), true));
+			cb.setSelected(Config.getPref().getBoolean("matsim_download_" + cb.getText(), true));
 			cb.addActionListener(cbListener);
 			highwaysPnl.add(cb, GBC.std());
 		}
@@ -48,7 +48,7 @@ public class DownloadDialog extends org.openstreetmap.josm.gui.download.Download
 		for (String routeType : OsmConvertDefaults.routeTypes) {
 			JCheckBox cb = new JCheckBox(routeType);
 			cb.setToolTipText(tr("Select to download " + cb.getText() + " routes in the selected download area."));
-			cb.setSelected(Main.pref.getBoolean("matsim_download_" + cb.getText(), true));
+			cb.setSelected(Config.getPref().getBoolean("matsim_download_" + cb.getText(), true));
 			cb.addActionListener(cbListener);
 			routesPnl.add(cb, GBC.std());
 		}
@@ -92,7 +92,7 @@ public class DownloadDialog extends org.openstreetmap.josm.gui.download.Download
 	 */
 	public void rememberSettings() {
 		if (currentBounds != null) {
-			Main.pref.put("osm-download.bounds", currentBounds.encodeAsString(";"));
+			Config.getPref().put("osm-download.bounds", currentBounds.encodeAsString(";"));
 		}
 	}
 }

--- a/src/main/java/org/matsim/contrib/josm/gui/LinksToggleDialog.java
+++ b/src/main/java/org/matsim/contrib/josm/gui/LinksToggleDialog.java
@@ -6,7 +6,7 @@ import org.matsim.contrib.josm.model.MATSimLayer;
 import org.matsim.contrib.josm.model.MLink;
 import org.matsim.contrib.josm.model.NetworkModel;
 import org.openstreetmap.josm.Main;
-import org.openstreetmap.josm.data.Preferences.PreferenceChangeEvent;
+import org.openstreetmap.josm.spi.preferences.PreferenceChangeEvent;
 import org.openstreetmap.josm.data.SelectionChangedListener;
 import org.openstreetmap.josm.data.osm.DataSet;
 import org.openstreetmap.josm.data.osm.OsmPrimitive;
@@ -152,7 +152,7 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 		tableModel_links.selectionChanged(null);
 	}
 
-	
+
 	@Override
 	public void preferenceChanged(PreferenceChangeEvent e) {
 		super.preferenceChanged(e);
@@ -353,8 +353,8 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 		}
 		notifyEverythingChanged();
 
-		
+
 	}
 
-	
+
 }

--- a/src/main/java/org/matsim/contrib/josm/gui/LinksToggleDialog.java
+++ b/src/main/java/org/matsim/contrib/josm/gui/LinksToggleDialog.java
@@ -17,6 +17,7 @@ import org.openstreetmap.josm.data.osm.event.DatasetEventManager;
 import org.openstreetmap.josm.data.osm.event.SelectionEventManager;
 import org.openstreetmap.josm.data.validation.OsmValidator;
 import org.openstreetmap.josm.data.validation.Test;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.dialogs.ToggleDialog;
 import org.openstreetmap.josm.gui.layer.Layer;
 import org.openstreetmap.josm.gui.layer.MainLayerManager.ActiveLayerChangeEvent;
@@ -60,7 +61,7 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 	public void showNotify() {
 		DatasetEventManager.getInstance().addDatasetListener(dataSetListenerAdapter, DatasetEventManager.FireMode.IN_EDT_CONSOLIDATED);
 		SelectionEventManager.getInstance().addSelectionListener(selectionListener, DatasetEventManager.FireMode.IN_EDT_CONSOLIDATED);
-		Main.getLayerManager().addActiveLayerChangeListener(this);
+		MainApplication.getLayerManager().addActiveLayerChangeListener(this);
 		notifyEverythingChanged();
 	}
 
@@ -68,7 +69,7 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 	public void hideNotify() {
 		DatasetEventManager.getInstance().removeDatasetListener(dataSetListenerAdapter);
 		SelectionEventManager.getInstance().removeSelectionListener(selectionListener);
-		Main.getLayerManager().removeActiveLayerChangeListener(this);
+		MainApplication.getLayerManager().removeActiveLayerChangeListener(this);
 		notifyEverythingChanged();
 	}
 
@@ -107,7 +108,7 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 
 	// called when MATSim data changes to update the data in this dialog
 	private void notifyEverythingChanged() {
-		OsmDataLayer layer = Main.getLayerManager().getEditLayer();
+		OsmDataLayer layer = MainApplication.getLayerManager().getEditLayer();
 		if (networkModel != null) {
 			networkModel.removeListener(this);
 		}
@@ -259,7 +260,7 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 		public void selectionChanged(Collection<? extends OsmPrimitive> newSelection) {
 			links.clear();
 			if (networkModel != null) {
-				DataSet currentDataSet = Main.getLayerManager().getEditDataSet();
+				DataSet currentDataSet = MainApplication.getLayerManager().getEditDataSet();
 				if (currentDataSet != null) {
 					currentDataSet.clearHighlightedWaySegments();
 					int i = 0;
@@ -282,7 +283,7 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 		// highlight and zoom to way segments that refer to the selected link in
 		// the table
 		public void valueChanged(ListSelectionEvent e) {
-			DataSet currentDataSet = Main.getLayerManager().getEditDataSet();
+			DataSet currentDataSet = MainApplication.getLayerManager().getEditDataSet();
 			if (currentDataSet != null) {
 				if (table_links.getSelectedRow() != -1) {
 					int row = table_links.convertRowIndexToModel(table_links.getSelectedRow());
@@ -292,7 +293,7 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 						currentDataSet.setHighlightedWaySegments(segments);
 					}
 				}
-				Main.map.mapView.repaint();
+				MainApplication.getMap().mapView.repaint();
 			}
 		}
 	}
@@ -306,7 +307,7 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 		private final JTextField capacityPeriodValue = new JTextField();
 
 		public NetworkAttributes() {
-			Layer layer = Main.getLayerManager().getActiveLayer();
+			Layer layer = MainApplication.getLayerManager().getActiveLayer();
 			if (layer instanceof MATSimLayer) {
 //				laneWidthValue.setText(String.valueOf(((MATSimLayer) layer).getNetworkModel().getScenario().getNetwork().getEffectiveLaneWidth()));
 //				capacityPeriodValue.setText(String.valueOf(((MATSimLayer) layer).getNetworkModel().getScenario().getNetwork().getCapacityPeriod()));
@@ -318,7 +319,7 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 		}
 
 		void apply() {
-			Layer layer = Main.getLayerManager().getActiveLayer();
+			Layer layer = MainApplication.getLayerManager().getActiveLayer();
 			if (layer instanceof MATSimLayer) {
 //				String lW = laneWidthValue.getText();
 //				String cP = capacityPeriodValue.getText();
@@ -339,7 +340,7 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 	// also adjusts standard file export formats
 	@Override
 	public void activeOrEditLayerChanged(ActiveLayerChangeEvent e) {
-		if(Main.getLayerManager().getActiveLayer() instanceof MATSimLayer) {
+		if(MainApplication.getLayerManager().getActiveLayer() instanceof MATSimLayer) {
 			for(Test test: OsmValidator.getTests()) {
 				test.enabled = test instanceof NetworkTest;
 			}

--- a/src/main/java/org/matsim/contrib/josm/gui/LinksToggleDialog.java
+++ b/src/main/java/org/matsim/contrib/josm/gui/LinksToggleDialog.java
@@ -15,6 +15,7 @@ import org.openstreetmap.josm.data.osm.WaySegment;
 import org.openstreetmap.josm.data.osm.event.DataSetListenerAdapter;
 import org.openstreetmap.josm.data.osm.event.DatasetEventManager;
 import org.openstreetmap.josm.data.osm.event.SelectionEventManager;
+import org.openstreetmap.josm.data.preferences.BooleanProperty;
 import org.openstreetmap.josm.data.validation.OsmValidator;
 import org.openstreetmap.josm.data.validation.Test;
 import org.openstreetmap.josm.gui.MainApplication;
@@ -163,7 +164,7 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 
 	// hecks if internal-id should be shown
 	private void checkInternalIdColumn() {
-		if (!Main.pref.getBoolean("matsim_showInternalIds", false)) {
+		if (!new BooleanProperty("matsim_showInternalIds", false).get()) {
 			table_links.getColumn("internal-id").setMinWidth(0);
 			table_links.getColumn("internal-id").setMaxWidth(0);
 		} else {

--- a/src/main/java/org/matsim/contrib/josm/gui/OsmConvertDefaultsDialog.java
+++ b/src/main/java/org/matsim/contrib/josm/gui/OsmConvertDefaultsDialog.java
@@ -2,7 +2,7 @@ package org.matsim.contrib.josm.gui;
 
 import org.matsim.contrib.josm.model.OsmConvertDefaults;
 import org.matsim.contrib.josm.model.OsmConvertDefaults.OsmWayDefaults;
-import org.openstreetmap.josm.Main;
+import org.openstreetmap.josm.spi.preferences.Config;
 import org.openstreetmap.josm.tools.ImageProvider;
 
 import javax.swing.*;
@@ -143,7 +143,7 @@ public class OsmConvertDefaultsDialog extends JPanel {
 			double laneCapacity = Double.parseDouble(((JTextField) input.get(i + "_4")).getText());
 			boolean oneway = (((JCheckBox) input.get(i + "_5")).isSelected());
 
-			Main.pref.put("matsim_convertDefaults_" + OsmConvertDefaults.highwayTypes.get(i), hierarchy + ";" + lanes + ";" + freespeed + ";"
+			Config.getPref().put("matsim_convertDefaults_" + OsmConvertDefaults.highwayTypes.get(i), hierarchy + ";" + lanes + ";" + freespeed + ";"
 					+ freespeedFactor + ";" + laneCapacity + ";" + oneway);
 		}
 	}

--- a/src/main/java/org/matsim/contrib/josm/gui/PTToggleDialog.java
+++ b/src/main/java/org/matsim/contrib/josm/gui/PTToggleDialog.java
@@ -222,7 +222,7 @@ public class PTToggleDialog extends ToggleDialog implements ActiveLayerChangeLis
 	}
 
 	private void enabledness() {
-		boolean enabled = Main.pref.getBoolean("matsim_supportTransit");
+		boolean enabled = Preferences.isSupportTransit();
 		getButton().setEnabled(enabled);
 		if (isShowing() && !enabled) {
 			hideDialog();

--- a/src/main/java/org/matsim/contrib/josm/gui/PTToggleDialog.java
+++ b/src/main/java/org/matsim/contrib/josm/gui/PTToggleDialog.java
@@ -36,6 +36,7 @@ import org.openstreetmap.josm.gui.layer.MainLayerManager.ActiveLayerChangeEvent;
 import org.openstreetmap.josm.gui.layer.MainLayerManager.ActiveLayerChangeListener;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
 import org.openstreetmap.josm.gui.util.HighlightHelper;
+import org.openstreetmap.josm.spi.preferences.PreferenceChangeEvent;
 
 import javax.swing.*;
 import java.util.ArrayList;
@@ -213,7 +214,7 @@ public class PTToggleDialog extends ToggleDialog implements ActiveLayerChangeLis
 	}
 
 	@Override
-	public void preferenceChanged(org.openstreetmap.josm.data.Preferences.PreferenceChangeEvent preferenceChangeEvent) {
+	public void preferenceChanged(PreferenceChangeEvent preferenceChangeEvent) {
 		super.preferenceChanged(preferenceChangeEvent);
 		if (preferenceChangeEvent.getKey().equalsIgnoreCase("matsim_supportTransit")) {
 			enabledness();

--- a/src/main/java/org/matsim/contrib/josm/gui/Preferences.java
+++ b/src/main/java/org/matsim/contrib/josm/gui/Preferences.java
@@ -6,6 +6,7 @@ import org.openstreetmap.josm.gui.preferences.PreferenceSetting;
 import org.openstreetmap.josm.gui.preferences.PreferenceSettingFactory;
 import org.openstreetmap.josm.gui.preferences.PreferenceTabbedPane;
 import org.openstreetmap.josm.gui.preferences.PreferenceTabbedPane.PreferencePanel;
+import org.openstreetmap.josm.spi.preferences.Config;
 
 import javax.swing.*;
 import java.awt.*;
@@ -67,18 +68,18 @@ public final class Preferences extends DefaultTabPreferenceSetting {
 
 	@Override
 	public boolean ok() {
-		Main.pref.put("matsim_networkVersion", (String)exportNetworkVersionCB.getSelectedItem());
-		Main.pref.put("matsim_supportTransit", transitFeature.isSelected());
-		Main.pref.put("matsim_transit_lite", transitLite.isSelected());
-		Main.pref.put("matsim_showIds", showIds.isSelected());
-		Main.pref.put("matsim_renderer", renderMatsim.isSelected());
-		Main.pref.put("matsim_cleanNetwork", cleanNetwork.isSelected());
-		Main.pref.put("matsim_keepPaths", keepPaths.isSelected());
-		Main.pref.put("matsim_showInternalIds", showInternalIds.isSelected());
-		Main.pref.put("matsim_filterActive", filterActive.isSelected());
-		Main.pref.put("matsim_includeRoadType", includeRoadType.isSelected());
-		Main.pref.putInteger("matsim_filter_hierarchy", Integer.parseInt(hierarchyLayer.getText()));
-		Main.pref.putDouble("matsim_wayOffset", ((double) wayOffset.getValue()) * 0.03);
+		Config.getPref().put("matsim_networkVersion", (String)exportNetworkVersionCB.getSelectedItem());
+		Config.getPref().putBoolean("matsim_supportTransit", transitFeature.isSelected());
+		Config.getPref().putBoolean("matsim_transit_lite", transitLite.isSelected());
+		Config.getPref().putBoolean("matsim_showIds", showIds.isSelected());
+		Config.getPref().putBoolean("matsim_renderer", renderMatsim.isSelected());
+		Config.getPref().putBoolean("matsim_cleanNetwork", cleanNetwork.isSelected());
+		Config.getPref().putBoolean("matsim_keepPaths", keepPaths.isSelected());
+		Config.getPref().putBoolean("matsim_showInternalIds", showInternalIds.isSelected());
+		Config.getPref().putBoolean("matsim_filterActive", filterActive.isSelected());
+		Config.getPref().putBoolean("matsim_includeRoadType", includeRoadType.isSelected());
+		Config.getPref().putInt("matsim_filter_hierarchy", Integer.parseInt(hierarchyLayer.getText()));
+		Config.getPref().putDouble("matsim_wayOffset", ((double) wayOffset.getValue()) * 0.03);
 		return false;
 	}
 
@@ -189,7 +190,7 @@ public final class Preferences extends DefaultTabPreferenceSetting {
 
 		includeRoadType.setSelected(Main.pref.getBoolean("matsim_includeRoadType", false));
 		filterActive.setSelected(Main.pref.getBoolean("matsim_filterActive", false));
-		hierarchyLayer.setText(String.valueOf(Main.pref.getInteger("matsim_filter_hierarchy", 6)));
+		hierarchyLayer.setText(String.valueOf(Config.getPref().getInt("matsim_filter_hierarchy", 6)));
 
 		cOptions.anchor = GridBagConstraints.NORTHWEST;
 
@@ -254,7 +255,7 @@ public final class Preferences extends DefaultTabPreferenceSetting {
 	}
 
 	public static void setSupportTransit(boolean supportTransit) {
-		Main.pref.put("matsim_supportTransit", supportTransit);
+		Config.getPref().putBoolean("matsim_supportTransit", supportTransit);
 	}
 
 	public static boolean includeRoadType() { return Main.pref.getBoolean("matsim_includeRoadType", false); }
@@ -264,11 +265,11 @@ public final class Preferences extends DefaultTabPreferenceSetting {
 	}
 
 	public static void setTransitLite(boolean transitLite) {
-		Main.pref.put("matsim_transit_lite", transitLite);
+		Config.getPref().putBoolean("matsim_transit_lite", transitLite);
 	}
 
 	public static int getMatsimFilterHierarchy() {
-		return Main.pref.getInteger("matsim_filter_hierarchy", 6);
+		return Config.getPref().getInt("matsim_filter_hierarchy", 6);
 	}
 
 }

--- a/src/main/java/org/matsim/contrib/josm/gui/Preferences.java
+++ b/src/main/java/org/matsim/contrib/josm/gui/Preferences.java
@@ -1,6 +1,9 @@
 package org.matsim.contrib.josm.gui;
 
 import org.openstreetmap.josm.Main;
+import org.openstreetmap.josm.data.preferences.BooleanProperty;
+import org.openstreetmap.josm.data.preferences.IntegerProperty;
+import org.openstreetmap.josm.data.preferences.StringProperty;
 import org.openstreetmap.josm.gui.preferences.DefaultTabPreferenceSetting;
 import org.openstreetmap.josm.gui.preferences.PreferenceSetting;
 import org.openstreetmap.josm.gui.preferences.PreferenceSettingFactory;
@@ -44,7 +47,16 @@ public final class Preferences extends DefaultTabPreferenceSetting {
 	private final JTextField hierarchyLayer = new JTextField();
 
 
-	public static class Factory implements PreferenceSettingFactory {
+	public static final BooleanProperty PROP_CLEAN_NETWORK = new BooleanProperty("matsim_cleanNetwork", true);
+	private static final IntegerProperty PROP_FILTER_HIERARCHY = new IntegerProperty("matsim_filter_hierarchy", 6);
+	private static final BooleanProperty PROP_INCLUDE_ROAD_TYPE = new BooleanProperty("matsim_includeRoadType", false);
+	private static final BooleanProperty PROP_KEEP_PATHS = new BooleanProperty("matsim_keepPaths", false);
+	private static final StringProperty PROP_NETWORK_VERSION = new StringProperty("matsim_networkVersion", "v2");
+	private static final BooleanProperty PROP_SUPPORT_TRANSIT = new BooleanProperty("matsim_supportTransit", false);
+	private static final BooleanProperty PROP_TRANSIT_LITE = new BooleanProperty("matsim_transit_lite", false);
+
+
+  public static class Factory implements PreferenceSettingFactory {
 		@Override
 		public PreferenceSetting createPreferenceSetting() {
 			return new Preferences();
@@ -68,17 +80,17 @@ public final class Preferences extends DefaultTabPreferenceSetting {
 
 	@Override
 	public boolean ok() {
-		Config.getPref().put("matsim_networkVersion", (String)exportNetworkVersionCB.getSelectedItem());
-		Config.getPref().putBoolean("matsim_supportTransit", transitFeature.isSelected());
-		Config.getPref().putBoolean("matsim_transit_lite", transitLite.isSelected());
+		PROP_NETWORK_VERSION.put((String) exportNetworkVersionCB.getSelectedItem());
+		setSupportTransit(transitFeature.isSelected());
+		setTransitLite(transitLite.isSelected());
 		Config.getPref().putBoolean("matsim_showIds", showIds.isSelected());
 		Config.getPref().putBoolean("matsim_renderer", renderMatsim.isSelected());
-		Config.getPref().putBoolean("matsim_cleanNetwork", cleanNetwork.isSelected());
-		Config.getPref().putBoolean("matsim_keepPaths", keepPaths.isSelected());
+		PROP_CLEAN_NETWORK.put(cleanNetwork.isSelected());
+		PROP_KEEP_PATHS.put(keepPaths.isSelected());
 		Config.getPref().putBoolean("matsim_showInternalIds", showInternalIds.isSelected());
 		Config.getPref().putBoolean("matsim_filterActive", filterActive.isSelected());
-		Config.getPref().putBoolean("matsim_includeRoadType", includeRoadType.isSelected());
-		Config.getPref().putInt("matsim_filter_hierarchy", Integer.parseInt(hierarchyLayer.getText()));
+		PROP_INCLUDE_ROAD_TYPE.put(includeRoadType.isSelected());
+		PROP_FILTER_HIERARCHY.put(Integer.parseInt(hierarchyLayer.getText()));
 		Config.getPref().putDouble("matsim_wayOffset", ((double) wayOffset.getValue()) * 0.03);
 		return false;
 	}
@@ -112,9 +124,9 @@ public final class Preferences extends DefaultTabPreferenceSetting {
 	private JPanel buildVisualizationPanel() {
 		JPanel pnl = new JPanel(new GridBagLayout());
 		GridBagConstraints cOptions = new GridBagConstraints();
-		wayOffset.setValue((int) ((Main.pref.getDouble("matsim_wayOffset", 0)) / 0.03));
-		showIds.setSelected(Main.pref.getBoolean("matsim_showIds"));
-		renderMatsim.setSelected(Main.pref.getBoolean("matsim_renderer"));
+		wayOffset.setValue((int) ((Config.getPref().getDouble("matsim_wayOffset", 0)) / 0.03));
+		showIds.setSelected(Config.getPref().getBoolean("matsim_showIds"));
+		renderMatsim.setSelected(Config.getPref().getBoolean("matsim_renderer"));
 		renderMatsim.addActionListener(e -> {
 			if (!renderMatsim.isSelected()) {
 				showIds.setSelected(false);
@@ -129,7 +141,7 @@ public final class Preferences extends DefaultTabPreferenceSetting {
 		wayOffset.setEnabled(renderMatsim.isSelected());
 		showIds.setEnabled(renderMatsim.isSelected());
 		wayOffsetLabel.setEnabled(renderMatsim.isSelected());
-		showInternalIds.setSelected(Main.pref.getBoolean("matsim_showInternalIds", false));
+		showInternalIds.setSelected(new BooleanProperty("matsim_showInternalIds", false).get());
 		cOptions.anchor = GridBagConstraints.NORTHWEST;
 		cOptions.insets = new Insets(4, 4, 4, 4);
 		cOptions.weightx = 0;
@@ -188,9 +200,9 @@ public final class Preferences extends DefaultTabPreferenceSetting {
 			dlg.dispose();
 		});
 
-		includeRoadType.setSelected(Main.pref.getBoolean("matsim_includeRoadType", false));
-		filterActive.setSelected(Main.pref.getBoolean("matsim_filterActive", false));
-		hierarchyLayer.setText(String.valueOf(Config.getPref().getInt("matsim_filter_hierarchy", 6)));
+		includeRoadType.setSelected(PROP_INCLUDE_ROAD_TYPE.get());
+		filterActive.setSelected(new BooleanProperty("matsim_filterActive", false).get());
+		hierarchyLayer.setText(String.valueOf(PROP_FILTER_HIERARCHY.get()));
 
 		cOptions.anchor = GridBagConstraints.NORTHWEST;
 
@@ -239,37 +251,39 @@ public final class Preferences extends DefaultTabPreferenceSetting {
 	}
 
 	public static String getNetworkExportVersion() {
-		return Main.pref.get("matsim_networkVersion", "v2");
+		return PROP_NETWORK_VERSION.get();
 	}
 
 	public static boolean isKeepPaths() {
-		return Main.pref.getBoolean("matsim_keepPaths", false);
+		return PROP_KEEP_PATHS.get();
 	}
 
 	public static boolean isCleanNetwork() {
-		return Main.pref.getBoolean("matsim_cleanNetwork", true);
+		return PROP_CLEAN_NETWORK.get();
 	}
 
 	public static boolean isSupportTransit() {
-		return Main.pref.getBoolean("matsim_supportTransit", false);
+		return PROP_SUPPORT_TRANSIT.get();
 	}
 
 	public static void setSupportTransit(boolean supportTransit) {
-		Config.getPref().putBoolean("matsim_supportTransit", supportTransit);
+		PROP_SUPPORT_TRANSIT.put(supportTransit);
 	}
 
-	public static boolean includeRoadType() { return Main.pref.getBoolean("matsim_includeRoadType", false); }
+	public static boolean includeRoadType() {
+		return PROP_INCLUDE_ROAD_TYPE.get();
+	}
 
 	public static boolean isTransitLite() {
-		return Main.pref.getBoolean("matsim_transit_lite", false);
+		return PROP_TRANSIT_LITE.get();
 	}
 
 	public static void setTransitLite(boolean transitLite) {
-		Config.getPref().putBoolean("matsim_transit_lite", transitLite);
+		PROP_TRANSIT_LITE.put(transitLite);
 	}
 
 	public static int getMatsimFilterHierarchy() {
-		return Config.getPref().getInt("matsim_filter_hierarchy", 6);
+		return PROP_FILTER_HIERARCHY.get();
 	}
 
 }

--- a/src/main/java/org/matsim/contrib/josm/gui/StopAreasToggleDialog.java
+++ b/src/main/java/org/matsim/contrib/josm/gui/StopAreasToggleDialog.java
@@ -1,5 +1,6 @@
 package org.matsim.contrib.josm.gui;
 
+import org.openstreetmap.josm.spi.preferences.PreferenceChangeEvent;
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.SimpleStringProperty;
@@ -99,7 +100,7 @@ public class StopAreasToggleDialog extends ToggleDialog implements MainLayerMana
 	}
 
 	@Override
-	public void preferenceChanged(org.openstreetmap.josm.data.Preferences.PreferenceChangeEvent preferenceChangeEvent) {
+	public void preferenceChanged(PreferenceChangeEvent preferenceChangeEvent) {
 		super.preferenceChanged(preferenceChangeEvent);
 		if (preferenceChangeEvent.getKey().equalsIgnoreCase("matsim_supportTransit")) {
 			enabledness();

--- a/src/main/java/org/matsim/contrib/josm/gui/StopAreasToggleDialog.java
+++ b/src/main/java/org/matsim/contrib/josm/gui/StopAreasToggleDialog.java
@@ -108,7 +108,7 @@ public class StopAreasToggleDialog extends ToggleDialog implements MainLayerMana
 	}
 
 	private void enabledness() {
-		boolean enabled = Main.pref.getBoolean("matsim_supportTransit");
+		boolean enabled = Preferences.isSupportTransit();
 		getButton().setEnabled(enabled);
 		if (isShowing() && !enabled) {
 			hideDialog();

--- a/src/main/java/org/matsim/contrib/josm/gui/StopAreasToggleDialog.java
+++ b/src/main/java/org/matsim/contrib/josm/gui/StopAreasToggleDialog.java
@@ -16,6 +16,7 @@ import org.matsim.contrib.josm.model.NetworkModel;
 import org.matsim.contrib.josm.model.StopArea;
 import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.data.osm.Relation;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.dialogs.ToggleDialog;
 import org.openstreetmap.josm.gui.layer.MainLayerManager;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
@@ -61,17 +62,17 @@ public class StopAreasToggleDialog extends ToggleDialog implements MainLayerMana
 
 	@Override
 	public void showNotify() {
-		Main.getLayerManager().addActiveLayerChangeListener(this);
+		MainApplication.getLayerManager().addActiveLayerChangeListener(this);
 	}
 
 	@Override
 	public void hideNotify() {
-		Main.getLayerManager().removeActiveLayerChangeListener(this);
+		MainApplication.getLayerManager().removeActiveLayerChangeListener(this);
 	}
 
 	@Override
 	public void activeOrEditLayerChanged(MainLayerManager.ActiveLayerChangeEvent activeLayerChangeEvent) {
-		editLayer = Main.getLayerManager().getEditLayer();
+		editLayer = MainApplication.getLayerManager().getEditLayer();
 		Platform.runLater(() -> {
 			if (editLayer != null) {
 				NetworkModel networkModel = NetworkModel.createNetworkModel(editLayer.data);

--- a/src/main/java/org/matsim/contrib/josm/model/NetworkModel.java
+++ b/src/main/java/org/matsim/contrib/josm/model/NetworkModel.java
@@ -11,8 +11,7 @@ import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.data.coor.EastNorth;
 import org.openstreetmap.josm.data.osm.*;
 import org.openstreetmap.josm.data.osm.event.*;
-import org.openstreetmap.josm.data.osm.visitor.AbstractVisitor;
-import org.openstreetmap.josm.data.osm.visitor.Visitor;
+import org.openstreetmap.josm.data.osm.visitor.OsmPrimitiveVisitor;
 import org.openstreetmap.josm.spi.preferences.IPreferences;
 
 import java.util.*;
@@ -225,7 +224,7 @@ public class NetworkModel {
 		fireNotifyDataChanged();
 	}
 
-	class AggregatePrimitives implements Visitor {
+	class AggregatePrimitives implements OsmPrimitiveVisitor {
 
 		Set<OsmPrimitive> primitives = new HashSet<>();
 
@@ -279,11 +278,6 @@ public class NetworkModel {
 			primitives.add(relation);
 		}
 
-		@Override
-		public void visit(Changeset changeset) {
-
-		}
-
 		void finished() {
 			Convert visitor = new Convert();
 			for (Node node : OsmPrimitive.getFilteredList(primitives, Node.class)) {
@@ -308,7 +302,7 @@ public class NetworkModel {
 		routes.remove(route.getRelation());
 	}
 
-	class Convert extends AbstractVisitor {
+	class Convert implements OsmPrimitiveVisitor {
 
 		final Collection<OsmPrimitive> visited = new HashSet<>();
 

--- a/src/main/java/org/matsim/contrib/josm/model/NetworkModel.java
+++ b/src/main/java/org/matsim/contrib/josm/model/NetworkModel.java
@@ -13,6 +13,7 @@ import org.openstreetmap.josm.data.osm.*;
 import org.openstreetmap.josm.data.osm.event.*;
 import org.openstreetmap.josm.data.osm.visitor.AbstractVisitor;
 import org.openstreetmap.josm.data.osm.visitor.Visitor;
+import org.openstreetmap.josm.spi.preferences.IPreferences;
 
 import java.util.*;
 
@@ -169,7 +170,7 @@ public class NetworkModel {
 	}
 
 	public static NetworkModel createNetworkModel(DataSet data, Map<Way, List<MLink>> way2Links) {
-		return new NetworkModel(data, Main.pref, way2Links);
+		return new NetworkModel(data, org.openstreetmap.josm.spi.preferences.Config.getPref(), way2Links);
 	}
 
 	public interface ScenarioDataChangedListener {
@@ -190,7 +191,7 @@ public class NetworkModel {
 		listeners.add(listener);
 	}
 
-	private NetworkModel(DataSet data, org.openstreetmap.josm.data.Preferences prefs, Map<Way, List<MLink>> way2Links) {
+	private NetworkModel(DataSet data, IPreferences prefs, Map<Way, List<MLink>> way2Links) {
 		this.data = data;
 		this.data.addDataSetListener(new NetworkModelDataSetListener());
 		prefs.addPreferenceChangeListener(e -> {

--- a/src/main/java/org/matsim/contrib/josm/model/OsmConvertDefaults.java
+++ b/src/main/java/org/matsim/contrib/josm/model/OsmConvertDefaults.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstreetmap.josm.Main;
-import org.openstreetmap.josm.data.Preferences;
+import org.openstreetmap.josm.spi.preferences.IPreferences;
 
 /**
  * Holds the default converting values
@@ -29,7 +29,7 @@ public class OsmConvertDefaults {
 		load();
 	}
 
-	public static void listen(Preferences pref) {
+	public static void listen(IPreferences pref) {
 		pref.addPreferenceChangeListener(preferenceChangeEvent -> load());
 	}
 

--- a/src/main/java/org/matsim/contrib/josm/model/OsmConvertDefaults.java
+++ b/src/main/java/org/matsim/contrib/josm/model/OsmConvertDefaults.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.openstreetmap.josm.Main;
+import org.openstreetmap.josm.data.preferences.StringProperty;
 import org.openstreetmap.josm.spi.preferences.IPreferences;
 
 /**
@@ -18,6 +18,8 @@ public class OsmConvertDefaults {
 
 	public static final List<String> highwayTypes = Arrays.asList("motorway", "motorway_link", "trunk", "trunk_link", "primary", "primary_link",
 			"secondary", "tertiary", "minor", "unclassified", "residential", "service", "living_street");
+
+	private static final Map<String, StringProperty> properties = new HashMap<>();
 
 	// This is an exhaustive list.
 	// See http://wiki.openstreetmap.org/wiki/Proposed_features/Public_Transport
@@ -39,28 +41,27 @@ public class OsmConvertDefaults {
 
 	private static void load() {
 
-		Map<String, String> values = new HashMap<>();
-		values.put("motorway", Main.pref.get("matsim_convertDefaults_motorway", "1;2;" + Double.toString(120. / 3.6) + ";1.0;2000;true"));
-		values.put("motorway_link", Main.pref.get("matsim_convertDefaults_motorway_link", "2;1;" + Double.toString(80. / 3.6) + ";1.0;1500;true"));
-		values.put("trunk", Main.pref.get("matsim_convertDefaults_trunk", "2;1;" + Double.toString(80. / 3.6) + ";1.0;2000;false"));
-		values.put("trunk_link", Main.pref.get("matsim_convertDefaults_trunk_link", "2;1;" + Double.toString(50. / 3.6) + ";1.0;1500;false"));
-		values.put("primary", Main.pref.get("matsim_convertDefaults_primary", "3;1;" + Double.toString(80. / 3.6) + ";1.0;1500;false"));
-		values.put("primary_link", Main.pref.get("matsim_convertDefaults_primary_link", "3;1;" + Double.toString(60. / 3.6) + ";1.0;1500;false"));
-		values.put("secondary", Main.pref.get("matsim_convertDefaults_secondary", "4;1;" + Double.toString(60. / 3.6) + ";1.0;1000;false"));
-		values.put("tertiary", Main.pref.get("matsim_convertDefaults_tertiary", "5;1;" + Double.toString(45. / 3.6) + ";1.0;600;false"));
-		values.put("minor", Main.pref.get("matsim_convertDefaults_minor", "6;1;" + Double.toString(45. / 3.6) + ";1.0;600;false"));
-		values.put("unclassified", Main.pref.get("matsim_convertDefaults_unclassified", "6;1;" + Double.toString(45. / 3.6) + ";1.0;600;false"));
-		values.put("residential", Main.pref.get("matsim_convertDefaults_residential", "6;1;" + Double.toString(30. / 3.6) + ";1.0;600;false"));
-		values.put("service", Main.pref.get("matsim_convertDefaults_service", "6;1;" + Double.toString(15. / 3.6) + ";1.0;300;false"));
-		values.put("living_street", Main.pref.get("matsim_convertDefaults_living_street", "6;1;" + Double.toString(15. / 3.6) + ";1.0;300;false"));
+		properties.put("motorway", new StringProperty("matsim_convertDefaults_motorway", "1;2;" + Double.toString(120. / 3.6) + ";1.0;2000;true"));
+		properties.put("motorway_link", new StringProperty("matsim_convertDefaults_motorway_link", "2;1;" + Double.toString(80. / 3.6) + ";1.0;1500;true"));
+		properties.put("trunk", new StringProperty("matsim_convertDefaults_trunk", "2;1;" + Double.toString(80. / 3.6) + ";1.0;2000;false"));
+		properties.put("trunk_link", new StringProperty("matsim_convertDefaults_trunk_link", "2;1;" + Double.toString(50. / 3.6) + ";1.0;1500;false"));
+		properties.put("primary", new StringProperty("matsim_convertDefaults_primary", "3;1;" + Double.toString(80. / 3.6) + ";1.0;1500;false"));
+		properties.put("primary_link", new StringProperty("matsim_convertDefaults_primary_link", "3;1;" + Double.toString(60. / 3.6) + ";1.0;1500;false"));
+		properties.put("secondary", new StringProperty("matsim_convertDefaults_secondary", "4;1;" + Double.toString(60. / 3.6) + ";1.0;1000;false"));
+		properties.put("tertiary", new StringProperty("matsim_convertDefaults_tertiary", "5;1;" + Double.toString(45. / 3.6) + ";1.0;600;false"));
+		properties.put("minor", new StringProperty("matsim_convertDefaults_minor", "6;1;" + Double.toString(45. / 3.6) + ";1.0;600;false"));
+		properties.put("unclassified", new StringProperty("matsim_convertDefaults_unclassified", "6;1;" + Double.toString(45. / 3.6) + ";1.0;600;false"));
+		properties.put("residential", new StringProperty("matsim_convertDefaults_residential", "6;1;" + Double.toString(30. / 3.6) + ";1.0;600;false"));
+		properties.put("service", new StringProperty("matsim_convertDefaults_service", "6;1;" + Double.toString(15. / 3.6) + ";1.0;300;false"));
+		properties.put("living_street", new StringProperty("matsim_convertDefaults_living_street", "6;1;" + Double.toString(15. / 3.6) + ";1.0;300;false"));
 
-		values.put("rail", Main.pref.get("matsim_convertDefaults_rail", "1;1;" + Double.toString(100 / 3.6) + ";1.0;" + Double.toString(Double.MAX_VALUE) + ";false"));
-		values.put("light_rail", Main.pref.get("matsim_convertDefaults_light_rail", "2;1;" + Double.toString(60 / 3.6) + ";1.0;" + Double.toString(Double.MAX_VALUE) + ";false"));
-		values.put("tram", Main.pref.get("matsim_convertDefaults_tram", "4;1;" + Double.toString(50 / 3.6) + ";1.0;" + Double.toString(Double.MAX_VALUE) + ";false"));
-		values.put("subway", Main.pref.get("matsim_convertDefaults_subway", "3;1;" + Double.toString(80 / 3.6) + ";1.0;" + Double.toString(Double.MAX_VALUE) + ";false"));
+		properties.put("rail", new StringProperty("matsim_convertDefaults_rail", "1;1;" + Double.toString(100 / 3.6) + ";1.0;" + Double.toString(Double.MAX_VALUE) + ";false"));
+		properties.put("light_rail", new StringProperty("matsim_convertDefaults_light_rail", "2;1;" + Double.toString(60 / 3.6) + ";1.0;" + Double.toString(Double.MAX_VALUE) + ";false"));
+		properties.put("tram", new StringProperty("matsim_convertDefaults_tram", "4;1;" + Double.toString(50 / 3.6) + ";1.0;" + Double.toString(Double.MAX_VALUE) + ";false"));
+		properties.put("subway", new StringProperty("matsim_convertDefaults_subway", "3;1;" + Double.toString(80 / 3.6) + ";1.0;" + Double.toString(Double.MAX_VALUE) + ";false"));
 
 		for (String type : highwayTypes) {
-			String temp = values.get(type);
+			String temp = properties.get(type).get();
 			String tempArray[] = temp.split(";");
 
 			int hierarchy = Integer.parseInt(tempArray[0]);
@@ -75,19 +76,9 @@ public class OsmConvertDefaults {
 	}
 
 	public static void reset() {
-		Main.pref.put("matsim_convertDefaults_motorway", "1;2;" + Double.toString(120. / 3.6) + ";1.0;2000;true");
-		Main.pref.put("matsim_convertDefaults_motorway_link", "2;1;" + Double.toString(80. / 3.6) + ";1.0;1500;true");
-		Main.pref.put("matsim_convertDefaults_trunk", "2;1;" + Double.toString(80. / 3.6) + ";1.0;2000;false");
-		Main.pref.put("matsim_convertDefaults_trunk_link", "2;1;" + Double.toString(50. / 3.6) + ";1.0;1500;false");
-		Main.pref.put("matsim_convertDefaults_primary", "3;1;" + Double.toString(80. / 3.6) + ";1.0;1500;false");
-		Main.pref.put("matsim_convertDefaults_primary_link", "3;1;" + Double.toString(60. / 3.6) + ";1.0;1500;false");
-		Main.pref.put("matsim_convertDefaults_secondary", "4;1;" + Double.toString(60. / 3.6) + ";1.0;1000;false");
-		Main.pref.put("matsim_convertDefaults_tertiary", "5;1;" + Double.toString(45. / 3.6) + ";1.0;600;false");
-		Main.pref.put("matsim_convertDefaults_minor", "6;1;" + Double.toString(45. / 3.6) + ";1.0;600;false");
-		Main.pref.put("matsim_convertDefaults_unclassified", "6;1;" + Double.toString(45. / 3.6) + ";1.0;600;false");
-		Main.pref.put("matsim_convertDefaults_residential", "6;1;" + Double.toString(30. / 3.6) + ";1.0;600;false");
-		Main.pref.put("matsim_convertDefaults_service", "6;1;" + Double.toString(15. / 3.6) + ";1.0;300;false");
-		Main.pref.put("matsim_convertDefaults_living_street", "6;1;" + Double.toString(15. / 3.6) + ";1.0;300;false");
+		for (String type : highwayTypes) {
+			properties.get(type).put(properties.get(type).getDefaultValue());
+		}
 	}
 
 	public static class OsmWayDefaults {
@@ -100,7 +91,7 @@ public class OsmConvertDefaults {
 		public final boolean oneway;
 
 		public OsmWayDefaults(final int hierarchy, final double lanesPerDirection, final double freespeed, final double freespeedFactor,
-							  final double laneCapacity, final boolean oneway) {
+							final double laneCapacity, final boolean oneway) {
 			this.hierarchy = hierarchy;
 			this.lanesPerDirection = lanesPerDirection;
 			this.freespeed = freespeed;

--- a/src/main/java/org/matsim/contrib/josm/model/Route.java
+++ b/src/main/java/org/matsim/contrib/josm/model/Route.java
@@ -4,8 +4,9 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.property.*;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+
+import org.matsim.contrib.josm.gui.Preferences;
 import org.matsim.pt.transitSchedule.api.Departure;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.data.osm.OsmPrimitive;
 import org.openstreetmap.josm.data.osm.Relation;
 import org.openstreetmap.josm.data.osm.RelationMember;
@@ -70,7 +71,7 @@ public class Route {
 	}
 
 	public ObservableList<MLink> getRoute() {
-		if (isExplicitelyMatsimTagged(relation.get()) || !Main.pref.getBoolean("matsim_transit_lite")) {
+		if (isExplicitelyMatsimTagged(relation.get()) || !Preferences.isTransitLite()) {
 			List<MLink> networkRoute = determineNetworkRoute(relation.get());
 			this.route.setAll(networkRoute);
 		}

--- a/src/main/java/org/matsim/contrib/josm/model/RouteStop.java
+++ b/src/main/java/org/matsim/contrib/josm/model/RouteStop.java
@@ -1,8 +1,5 @@
 package org.matsim.contrib.josm.model;
 
-import org.matsim.pt.transitSchedule.api.TransitRouteStop;
-import org.matsim.pt.transitSchedule.api.TransitStopFacility;
-
 public class RouteStop {
 	private boolean awaitDepartureTime;
 	private double departureOffset;

--- a/src/main/java/org/matsim/contrib/josm/model/StopArea.java
+++ b/src/main/java/org/matsim/contrib/josm/model/StopArea.java
@@ -18,7 +18,6 @@ import org.openstreetmap.josm.plugins.jts.JTSUtils;
 import org.openstreetmap.josm.tools.Geometry;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 public class StopArea {

--- a/src/main/java/org/matsim/contrib/osm/CreateStopAreas.java
+++ b/src/main/java/org/matsim/contrib/osm/CreateStopAreas.java
@@ -196,9 +196,9 @@ public class CreateStopAreas extends Test {
 					newStopArea.addMember(new RelationMember("platform", stop));
 				}
 				newStopArea.getMembers().addAll(stopArea.getMembers());
-				commands.add(new ChangeCommand(MainApplication.getLayerManager().getEditLayer(), oldStopArea, newStopArea));
+				commands.add(new ChangeCommand(MainApplication.getLayerManager().getEditLayer().data, oldStopArea, newStopArea));
 			} else {
-				commands.add(new AddCommand(MainApplication.getLayerManager().getEditLayer(), stopArea));
+				commands.add(new AddCommand(MainApplication.getLayerManager().getEditLayer().data, stopArea));
 			}
 			return new SequenceCommand(name, commands);
 		}

--- a/src/main/java/org/matsim/contrib/osm/CreateStopAreas.java
+++ b/src/main/java/org/matsim/contrib/osm/CreateStopAreas.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.command.AddCommand;
 import org.openstreetmap.josm.command.ChangeCommand;
 import org.openstreetmap.josm.command.Command;
@@ -21,6 +20,7 @@ import org.openstreetmap.josm.data.osm.Way;
 import org.openstreetmap.josm.data.validation.Severity;
 import org.openstreetmap.josm.data.validation.Test;
 import org.openstreetmap.josm.data.validation.TestError;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.progress.ProgressMonitor;
 
 public class CreateStopAreas extends Test {
@@ -196,9 +196,9 @@ public class CreateStopAreas extends Test {
 					newStopArea.addMember(new RelationMember("platform", stop));
 				}
 				newStopArea.getMembers().addAll(stopArea.getMembers());
-				commands.add(new ChangeCommand(Main.getLayerManager().getEditLayer(), oldStopArea, newStopArea));
+				commands.add(new ChangeCommand(MainApplication.getLayerManager().getEditLayer(), oldStopArea, newStopArea));
 			} else {
-				commands.add(new AddCommand(Main.getLayerManager().getEditLayer(), stopArea));
+				commands.add(new AddCommand(MainApplication.getLayerManager().getEditLayer(), stopArea));
 			}
 			return new SequenceCommand(name, commands);
 		}

--- a/src/main/java/org/matsim/contrib/osm/IncompleteRoutesTest.java
+++ b/src/main/java/org/matsim/contrib/osm/IncompleteRoutesTest.java
@@ -4,13 +4,13 @@ import static org.openstreetmap.josm.tools.I18n.tr;
 
 import java.util.ArrayList;
 
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.command.Command;
 import org.openstreetmap.josm.data.osm.OsmPrimitive;
 import org.openstreetmap.josm.data.osm.Relation;
 import org.openstreetmap.josm.data.validation.Severity;
 import org.openstreetmap.josm.data.validation.Test;
 import org.openstreetmap.josm.data.validation.TestError;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.dialogs.relation.DownloadRelationMemberTask;
 import org.openstreetmap.josm.gui.progress.ProgressMonitor;
 
@@ -80,7 +80,7 @@ public class IncompleteRoutesTest extends Test{
 		}
 		if (testError.getCode() == 3010) {
 			for(OsmPrimitive primitive: testError.getPrimitives()) {
-				Main.worker.submit(new DownloadRelationMemberTask((Relation) primitive, ((Relation) primitive).getIncompleteMembers(), Main.getLayerManager().getEditLayer()));
+				MainApplication.worker.submit(new DownloadRelationMemberTask((Relation) primitive, ((Relation) primitive).getIncompleteMembers(), MainApplication.getLayerManager().getEditLayer()));
 			}
 
 		}

--- a/src/main/java/org/matsim/contrib/osm/MasterRoutesTest.java
+++ b/src/main/java/org/matsim/contrib/osm/MasterRoutesTest.java
@@ -153,9 +153,9 @@ public class MasterRoutesTest extends Test {
 					}
 				}
 				newMaster.getMembers().addAll(master.getMembers());
-				commands.add(new ChangeCommand(MainApplication.getLayerManager().getEditLayer(), oldMaster, newMaster));
+				commands.add(new ChangeCommand(MainApplication.getLayerManager().getEditLayer().data, oldMaster, newMaster));
 			} else {
-				commands.add(new AddCommand(MainApplication.getLayerManager().getEditLayer(), master));
+				commands.add(new AddCommand(MainApplication.getLayerManager().getEditLayer().data, master));
 			}
 			return new SequenceCommand(name, commands);
 		}

--- a/src/main/java/org/matsim/contrib/osm/MasterRoutesTest.java
+++ b/src/main/java/org/matsim/contrib/osm/MasterRoutesTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.command.AddCommand;
 import org.openstreetmap.josm.command.ChangeCommand;
 import org.openstreetmap.josm.command.Command;
@@ -19,6 +18,7 @@ import org.openstreetmap.josm.data.osm.RelationMember;
 import org.openstreetmap.josm.data.validation.Severity;
 import org.openstreetmap.josm.data.validation.Test;
 import org.openstreetmap.josm.data.validation.TestError;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.progress.ProgressMonitor;
 
 /**
@@ -153,9 +153,9 @@ public class MasterRoutesTest extends Test {
 					}
 				}
 				newMaster.getMembers().addAll(master.getMembers());
-				commands.add(new ChangeCommand(Main.getLayerManager().getEditLayer(), oldMaster, newMaster));
+				commands.add(new ChangeCommand(MainApplication.getLayerManager().getEditLayer(), oldMaster, newMaster));
 			} else {
-				commands.add(new AddCommand(Main.getLayerManager().getEditLayer(), master));
+				commands.add(new AddCommand(MainApplication.getLayerManager().getEditLayer(), master));
 			}
 			return new SequenceCommand(name, commands);
 		}

--- a/src/main/java/org/matsim/contrib/osm/RepairAction.java
+++ b/src/main/java/org/matsim/contrib/osm/RepairAction.java
@@ -4,11 +4,11 @@ import static org.openstreetmap.josm.tools.I18n.tr;
 
 import java.awt.event.ActionEvent;
 
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.actions.JosmAction;
 import org.openstreetmap.josm.data.osm.DataSet;
 import org.openstreetmap.josm.data.validation.OsmValidator;
 import org.openstreetmap.josm.data.validation.Test;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.progress.swing.PleaseWaitProgressMonitor;
 
 /**
@@ -29,7 +29,7 @@ public class RepairAction extends JosmAction {
 
 	@Override
 	public void actionPerformed(ActionEvent e) {
-		DataSet data = Main.getLayerManager().getEditDataSet();
+		DataSet data = MainApplication.getLayerManager().getEditDataSet();
 		PleaseWaitProgressMonitor progMonitor = new PleaseWaitProgressMonitor(
 				"Validation");
 
@@ -42,10 +42,10 @@ public class RepairAction extends JosmAction {
 
 		// set up validator layer
 		OsmValidator.initializeErrorLayer();
-		Main.map.validatorDialog.unfurlDialog();
-		Main.getLayerManager().getEditLayer().validationErrors.clear();
-		Main.getLayerManager().getEditLayer().validationErrors.addAll(test.getErrors());
-		Main.map.validatorDialog.tree.setErrors(test.getErrors());
+		MainApplication.getMap().validatorDialog.unfurlDialog();
+		MainApplication.getLayerManager().getEditLayer().validationErrors.clear();
+		MainApplication.getLayerManager().getEditLayer().validationErrors.addAll(test.getErrors());
+		MainApplication.getMap().validatorDialog.tree.setErrors(test.getErrors());
 	}
 
 
@@ -58,6 +58,6 @@ public class RepairAction extends JosmAction {
 
 
 	private boolean shouldBeEnabled() {
-		return Main.getLayerManager().getEditDataSet() != null;
+		return MainApplication.getLayerManager().getEditDataSet() != null;
 	}
 }

--- a/src/main/java/org/matsim/contrib/osm/UpdateStopTags.java
+++ b/src/main/java/org/matsim/contrib/osm/UpdateStopTags.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.command.ChangePropertyCommand;
 import org.openstreetmap.josm.command.Command;
 import org.openstreetmap.josm.command.SequenceCommand;

--- a/src/test/java/org/matsim/contrib/josm/CreatePseudoTransitTest.java
+++ b/src/test/java/org/matsim/contrib/josm/CreatePseudoTransitTest.java
@@ -2,6 +2,7 @@ package org.matsim.contrib.josm;
 
 import org.junit.Rule;
 import org.matsim.api.core.v01.Scenario;
+import org.matsim.contrib.josm.gui.Preferences;
 import org.matsim.contrib.josm.model.Export;
 import org.matsim.contrib.josm.model.LayerConverter;
 import org.matsim.contrib.josm.model.MATSimLayer;
@@ -49,7 +50,7 @@ public class CreatePseudoTransitTest {
 		System.out.println(main);
 		OsmDataLayer layer = new OsmDataLayer(set, "tmp", null);
 
-		org.openstreetmap.josm.spi.preferences.Config.getPref().putBoolean("matsim_supportTransit", true);
+		Preferences.setSupportTransit(true);
 		Config config = ConfigUtils.createConfig();
 		config.transit().setUseTransit(true);
 		NetworkModel listener = NetworkModel.createNetworkModel(set);

--- a/src/test/java/org/matsim/contrib/josm/CreatePseudoTransitTest.java
+++ b/src/test/java/org/matsim/contrib/josm/CreatePseudoTransitTest.java
@@ -15,11 +15,11 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.network.io.NetworkWriter;
 import org.matsim.pt.transitSchedule.api.TransitScheduleWriter;
 import org.openstreetmap.josm.Main;
-import org.openstreetmap.josm.actions.JosmAction;
 import org.openstreetmap.josm.command.Command;
 import org.openstreetmap.josm.data.osm.DataSet;
 import org.openstreetmap.josm.data.validation.Test;
 import org.openstreetmap.josm.data.validation.TestError;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
 import org.openstreetmap.josm.io.IllegalDataException;
 import org.openstreetmap.josm.io.OsmReader;
@@ -54,8 +54,8 @@ public class CreatePseudoTransitTest {
 		config.transit().setUseTransit(true);
 		NetworkModel listener = NetworkModel.createNetworkModel(set);
 		listener.visitAll();
-		Main.getLayerManager().addLayer(layer);
-		Main.getLayerManager().setActiveLayer(layer);
+		MainApplication.getLayerManager().addLayer(layer);
+		MainApplication.getLayerManager().setActiveLayer(layer);
 		System.out.println("Layer added");
 
 		System.out.println("Starting Validations");
@@ -82,7 +82,7 @@ public class CreatePseudoTransitTest {
 			}
 		}
 
-		MATSimLayer matSimLayer = LayerConverter.convertToPseudoNetwork(Main.getLayerManager().getEditLayer());
+		MATSimLayer matSimLayer = LayerConverter.convertToPseudoNetwork(MainApplication.getLayerManager().getEditLayer());
 		Scenario targetScenario = Export.toScenario(matSimLayer.getNetworkModel());
 		new NetworkWriter(targetScenario.getNetwork()).write(new File("pseudo-network.xml").getPath());
 		new TransitScheduleWriter(targetScenario.getTransitSchedule()).writeFile(new File("pseudo-transitSchedule.xml").getPath());

--- a/src/test/java/org/matsim/contrib/josm/CreatePseudoTransitTest.java
+++ b/src/test/java/org/matsim/contrib/josm/CreatePseudoTransitTest.java
@@ -49,7 +49,7 @@ public class CreatePseudoTransitTest {
 		System.out.println(main);
 		OsmDataLayer layer = new OsmDataLayer(set, "tmp", null);
 
-		Main.pref.put("matsim_supportTransit", true);
+		org.openstreetmap.josm.spi.preferences.Config.getPref().putBoolean("matsim_supportTransit", true);
 		Config config = ConfigUtils.createConfig();
 		config.transit().setUseTransit(true);
 		NetworkModel listener = NetworkModel.createNetworkModel(set);

--- a/src/test/java/org/matsim/contrib/josm/CreateTransitFromCompleteDataTest.java
+++ b/src/test/java/org/matsim/contrib/josm/CreateTransitFromCompleteDataTest.java
@@ -3,6 +3,7 @@ package org.matsim.contrib.josm;
 import org.junit.Rule;
 import org.junit.Test;
 import org.matsim.api.core.v01.Scenario;
+import org.matsim.contrib.josm.gui.Preferences;
 import org.matsim.contrib.josm.model.Export;
 import org.matsim.contrib.josm.model.LayerConverter;
 import org.matsim.contrib.josm.model.MATSimLayer;
@@ -30,7 +31,7 @@ public class CreateTransitFromCompleteDataTest {
 
 	@Test
 	public void createTransit() throws IllegalDataException, IOException {
-		org.openstreetmap.josm.spi.preferences.Config.getPref().putBoolean("matsim_supportTransit", true);
+		Preferences.setSupportTransit(true);
 		InputStream stream = getClass().getResourceAsStream("/test-input/OSMData/busRoute-with-complete-tags.osm.xml");
 		DataSet set = OsmReader.parseDataSet(stream, null);
 

--- a/src/test/java/org/matsim/contrib/josm/CreateTransitFromCompleteDataTest.java
+++ b/src/test/java/org/matsim/contrib/josm/CreateTransitFromCompleteDataTest.java
@@ -13,6 +13,7 @@ import org.matsim.core.network.io.NetworkWriter;
 import org.matsim.pt.transitSchedule.api.TransitScheduleWriter;
 import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.data.osm.DataSet;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
 import org.openstreetmap.josm.io.IllegalDataException;
 import org.openstreetmap.josm.io.OsmReader;
@@ -40,12 +41,12 @@ public class CreateTransitFromCompleteDataTest {
 		config.transit().setUseTransit(true);
 		NetworkModel listener = NetworkModel.createNetworkModel(set);
 		listener.visitAll();
-		Main.getLayerManager().addLayer(layer);
-		Main.getLayerManager().setActiveLayer(layer);
+		MainApplication.getLayerManager().addLayer(layer);
+		MainApplication.getLayerManager().setActiveLayer(layer);
 
-		Main.getLayerManager().addLayer(LayerConverter.convertWithFullTransit(layer));
+		MainApplication.getLayerManager().addLayer(LayerConverter.convertWithFullTransit(layer));
 
-		Scenario targetScenario = Export.toScenario(((MATSimLayer) Main.getLayerManager().getActiveLayer()).getNetworkModel());
+		Scenario targetScenario = Export.toScenario(((MATSimLayer) MainApplication.getLayerManager().getActiveLayer()).getNetworkModel());
 		new NetworkWriter(targetScenario.getNetwork()).write(new File("network-2.xml").getPath());
 		new TransitScheduleWriter(targetScenario.getTransitSchedule()).writeFile(new File("transitSchedule-2.xml").getPath());
 	}

--- a/src/test/java/org/matsim/contrib/josm/CreateTransitFromCompleteDataTest.java
+++ b/src/test/java/org/matsim/contrib/josm/CreateTransitFromCompleteDataTest.java
@@ -11,7 +11,6 @@ import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.network.io.NetworkWriter;
 import org.matsim.pt.transitSchedule.api.TransitScheduleWriter;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.data.osm.DataSet;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
@@ -31,7 +30,7 @@ public class CreateTransitFromCompleteDataTest {
 
 	@Test
 	public void createTransit() throws IllegalDataException, IOException {
-		Main.pref.put("matsim_supportTransit", true);
+		org.openstreetmap.josm.spi.preferences.Config.getPref().putBoolean("matsim_supportTransit", true);
 		InputStream stream = getClass().getResourceAsStream("/test-input/OSMData/busRoute-with-complete-tags.osm.xml");
 		DataSet set = OsmReader.parseDataSet(stream, null);
 

--- a/src/test/java/org/matsim/contrib/josm/CreateTransitFromIncompleteDataTest.java
+++ b/src/test/java/org/matsim/contrib/josm/CreateTransitFromIncompleteDataTest.java
@@ -3,6 +3,7 @@ package org.matsim.contrib.josm;
 import org.junit.Rule;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.josm.actions.TransitScheduleTest;
+import org.matsim.contrib.josm.gui.Preferences;
 import org.matsim.contrib.josm.model.Export;
 import org.matsim.contrib.josm.model.LayerConverter;
 import org.matsim.contrib.josm.model.MATSimLayer;
@@ -40,7 +41,7 @@ public class CreateTransitFromIncompleteDataTest {
 
 	@org.junit.Test
 	public void createTransit() throws IllegalDataException, IOException {
-		org.openstreetmap.josm.spi.preferences.Config.getPref().putBoolean("matsim_supportTransit", true);
+		Preferences.setSupportTransit(true);
 
 		System.out.println("Fixture initialized");
 

--- a/src/test/java/org/matsim/contrib/josm/CreateTransitFromIncompleteDataTest.java
+++ b/src/test/java/org/matsim/contrib/josm/CreateTransitFromIncompleteDataTest.java
@@ -15,7 +15,6 @@ import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.network.io.NetworkWriter;
 import org.matsim.pt.transitSchedule.api.TransitScheduleWriter;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.command.Command;
 import org.openstreetmap.josm.data.osm.DataSet;
 import org.openstreetmap.josm.data.validation.Test;
@@ -41,7 +40,7 @@ public class CreateTransitFromIncompleteDataTest {
 
 	@org.junit.Test
 	public void createTransit() throws IllegalDataException, IOException {
-		Main.pref.put("matsim_supportTransit", true);
+		org.openstreetmap.josm.spi.preferences.Config.getPref().putBoolean("matsim_supportTransit", true);
 
 		System.out.println("Fixture initialized");
 

--- a/src/test/java/org/matsim/contrib/josm/CreateTransitFromIncompleteDataTest.java
+++ b/src/test/java/org/matsim/contrib/josm/CreateTransitFromIncompleteDataTest.java
@@ -20,6 +20,7 @@ import org.openstreetmap.josm.command.Command;
 import org.openstreetmap.josm.data.osm.DataSet;
 import org.openstreetmap.josm.data.validation.Test;
 import org.openstreetmap.josm.data.validation.TestError;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
 import org.openstreetmap.josm.gui.progress.swing.PleaseWaitProgressMonitor;
 import org.openstreetmap.josm.io.IllegalDataException;
@@ -55,8 +56,8 @@ public class CreateTransitFromIncompleteDataTest {
 		config.transit().setUseTransit(true);
 		NetworkModel listener = NetworkModel.createNetworkModel(set);
 		listener.visitAll();
-		Main.getLayerManager().addLayer(layer);
-		Main.getLayerManager().setActiveLayer(layer);
+		MainApplication.getLayerManager().addLayer(layer);
+		MainApplication.getLayerManager().setActiveLayer(layer);
 		System.out.println("Layer added");
 
 		System.out.println("Starting Validations");
@@ -84,7 +85,7 @@ public class CreateTransitFromIncompleteDataTest {
 		}
 
 		System.out.println("Converting data");
-		Main.getLayerManager().addLayer(LayerConverter.convertWithFullTransit(layer));
+		MainApplication.getLayerManager().addLayer(LayerConverter.convertWithFullTransit(layer));
 		System.out.println("Exporting data");
 
 		TransitScheduleTest test = new TransitScheduleTest();
@@ -92,7 +93,7 @@ public class CreateTransitFromIncompleteDataTest {
 				PleaseWaitProgressMonitor("Validation");
 		// convertWithFullTransit validator tests
 		test.startTest(progMonitor);
-		test.visit(Main.getLayerManager().getEditDataSet().allPrimitives());
+		test.visit(MainApplication.getLayerManager().getEditDataSet().allPrimitives());
 		test.endTest();
 		progMonitor.finishTask();
 		progMonitor.close();
@@ -106,7 +107,7 @@ public class CreateTransitFromIncompleteDataTest {
 			}
 		}
 
-		Scenario targetScenario = Export.toScenario(((MATSimLayer) Main.getLayerManager().getActiveLayer()).getNetworkModel());
+		Scenario targetScenario = Export.toScenario(((MATSimLayer) MainApplication.getLayerManager().getActiveLayer()).getNetworkModel());
 		new NetworkWriter(targetScenario.getNetwork()).write(new File("network.xml").getPath());
 		new TransitScheduleWriter(targetScenario.getTransitSchedule()).writeFile(new File("transitSchedule.xml").getPath());
 	}

--- a/src/test/java/org/matsim/contrib/josm/IOTest.java
+++ b/src/test/java/org/matsim/contrib/josm/IOTest.java
@@ -50,7 +50,7 @@ public class IOTest {
 		int nLinks = scenario.getNetwork().getLinks().size();
 		List<Command> commands = new ArrayList<>();
 		for (Way way : layer.data.getWays()) {
-			Command delete = DeleteCommand.delete(layer, Arrays.asList(way), false, true);
+			Command delete = DeleteCommand.delete(Arrays.asList(way), false, true);
 			delete.executeCommand();
 			commands.add(delete);
 			nLinks--;
@@ -67,7 +67,7 @@ public class IOTest {
 	private void deleteAndUndeleteLinks(Scenario scenario, MATSimLayer layer) {
 		Assert.assertEquals(scenario.getNetwork().getNodes().size(), layer.getNetworkModel().nodes().size());
 		Assert.assertEquals(scenario.getNetwork().getLinks().size(), layer.getNetworkModel().getWay2Links().values().stream().mapToInt(List::size).sum());
-		Command delete = DeleteCommand.delete(layer, layer.data.getWays(), false, true);
+		Command delete = DeleteCommand.delete(layer.data.getWays(), false, true);
 		delete.executeCommand();
 		Assert.assertEquals(0, layer.getNetworkModel().nodes().size());
 		Assert.assertEquals(0, layer.getNetworkModel().getWay2Links().values().stream().mapToInt(List::size).sum());
@@ -79,7 +79,7 @@ public class IOTest {
 	private void deleteAndUndeleteEverything(Scenario scenario, MATSimLayer layer) {
 		Assert.assertEquals(scenario.getNetwork().getNodes().size(), layer.getNetworkModel().nodes().size());
 		Assert.assertEquals(scenario.getNetwork().getLinks().size(), layer.getNetworkModel().getWay2Links().values().stream().mapToInt(List::size).sum());
-		Command delete = DeleteCommand.delete(layer, layer.data.allPrimitives(), true, true);
+		Command delete = DeleteCommand.delete(layer.data.allPrimitives(), true, true);
 		delete.executeCommand();
 		Assert.assertEquals(0, layer.getNetworkModel().nodes().size());
 		Assert.assertEquals(0, layer.getNetworkModel().getWay2Links().values().stream().mapToInt(List::size).sum());
@@ -156,7 +156,7 @@ public class IOTest {
 		List<Command> commands = new ArrayList<>();
 		for(Relation relation: layer.data.getRelations()) {
 			if(relation.hasTag("type", "public_transport") && relation.hasTag("public_transport", "stop_area")) {
-				Command delete = DeleteCommand.delete(layer, Arrays.asList(relation), false, true);
+				Command delete = DeleteCommand.delete(Arrays.asList(relation), false, true);
 				delete.executeCommand();
 				commands.add(delete);
 			}

--- a/src/test/java/org/matsim/contrib/josm/InteractiveEditingTest.java
+++ b/src/test/java/org/matsim/contrib/josm/InteractiveEditingTest.java
@@ -7,7 +7,6 @@ import org.matsim.contrib.josm.actions.NewNetworkAction;
 import org.matsim.contrib.josm.gui.Preferences;
 import org.matsim.contrib.josm.model.LinkConversionRules;
 import org.matsim.contrib.josm.model.MATSimLayer;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.command.AddCommand;
 import org.openstreetmap.josm.command.ChangePropertyCommand;
 import org.openstreetmap.josm.command.DeleteCommand;
@@ -15,6 +14,7 @@ import org.openstreetmap.josm.command.MoveCommand;
 import org.openstreetmap.josm.data.coor.LatLon;
 import org.openstreetmap.josm.data.osm.Node;
 import org.openstreetmap.josm.data.osm.Way;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.testutils.JOSMTestRules;
 
 import java.util.List;
@@ -28,7 +28,7 @@ public class InteractiveEditingTest {
 	@Test
 	public void createLink() {
 		MATSimLayer matsimLayer = NewNetworkAction.createMatsimLayer();
-		Main.getLayerManager().addLayer(matsimLayer);
+		MainApplication.getLayerManager().addLayer(matsimLayer);
 		Node node1 = new Node();
 		node1.setCoor(new LatLon(0.0, 0.0));
 		new AddCommand(matsimLayer, node1).executeCommand();
@@ -49,7 +49,7 @@ public class InteractiveEditingTest {
 	@Test
 	public void createLinkUndo() {
 		MATSimLayer matsimLayer = NewNetworkAction.createMatsimLayer();
-		Main.getLayerManager().addLayer(matsimLayer);
+		MainApplication.getLayerManager().addLayer(matsimLayer);
 		Node node1 = new Node();
 		node1.setCoor(new LatLon(0.0, 0.0));
 		AddCommand addNode1 = new AddCommand(matsimLayer, node1);
@@ -81,7 +81,7 @@ public class InteractiveEditingTest {
 	@Test
 	public void createLinkDeleteUndoDelete() {
 		MATSimLayer matsimLayer = NewNetworkAction.createMatsimLayer();
-		Main.getLayerManager().addLayer(matsimLayer);
+		MainApplication.getLayerManager().addLayer(matsimLayer);
 		Node node1 = new Node();
 		node1.setCoor(new LatLon(0.0, 0.0));
 		new AddCommand(matsimLayer, node1).executeCommand();
@@ -105,7 +105,7 @@ public class InteractiveEditingTest {
 	@Test
 	public void createLinkDeleteWithNodesUndoDelete() {
 		MATSimLayer matsimLayer = NewNetworkAction.createMatsimLayer();
-		Main.getLayerManager().addLayer(matsimLayer);
+		MainApplication.getLayerManager().addLayer(matsimLayer);
 		Node node1 = new Node();
 		node1.setCoor(new LatLon(0.0, 0.0));
 		new AddCommand(matsimLayer, node1).executeCommand();
@@ -140,7 +140,7 @@ public class InteractiveEditingTest {
 	@Test
 	public void createLinkThenSetMatsimAttribtues() {
 		MATSimLayer matsimLayer = NewNetworkAction.createMatsimLayer();
-		Main.getLayerManager().addLayer(matsimLayer);
+		MainApplication.getLayerManager().addLayer(matsimLayer);
 		Node node1 = new Node();
 		node1.setCoor(new LatLon(0.0, 0.0));
 		new AddCommand(matsimLayer, node1).executeCommand();
@@ -164,7 +164,7 @@ public class InteractiveEditingTest {
 		Preferences.setSupportTransit(true);
 		Preferences.setTransitLite(true);
 		MATSimLayer matsimLayer = PtTutorialScenario.layer();
-		Main.getLayerManager().addLayer(matsimLayer);
+		MainApplication.getLayerManager().addLayer(matsimLayer);
 		Assert.assertEquals(4, matsimLayer.getNetworkModel().stopAreas().size());
 
 		Node node2 = findNode2(matsimLayer);

--- a/src/test/java/org/matsim/contrib/josm/InteractiveEditingTest.java
+++ b/src/test/java/org/matsim/contrib/josm/InteractiveEditingTest.java
@@ -23,7 +23,7 @@ public class InteractiveEditingTest {
 
 	@Rule
 	public JOSMTestRules test = new JOSMTestRules().preferences();
-	
+
 
 	@Test
 	public void createLink() {
@@ -31,10 +31,10 @@ public class InteractiveEditingTest {
 		MainApplication.getLayerManager().addLayer(matsimLayer);
 		Node node1 = new Node();
 		node1.setCoor(new LatLon(0.0, 0.0));
-		new AddCommand(matsimLayer, node1).executeCommand();
+		new AddCommand(matsimLayer.data, node1).executeCommand();
 		Node node2 = new Node();
 		node2.setCoor(new LatLon(0.1, 0.1));
-		new AddCommand(matsimLayer, node2).executeCommand();
+		new AddCommand(matsimLayer.data, node2).executeCommand();
 		Way way = new Way();
 		way.addNode(node1);
 		way.addNode(node2);
@@ -42,7 +42,7 @@ public class InteractiveEditingTest {
 		way.put(LinkConversionRules.CAPACITY, "1000.0");
 		way.put(LinkConversionRules.PERMLANES, "1.0");
 		way.put(LinkConversionRules.MODES, "car");
-		new AddCommand(matsimLayer, way).executeCommand();
+		new AddCommand(matsimLayer.data, way).executeCommand();
 		Assert.assertEquals(1, matsimLayer.getNetworkModel().getWay2Links().values().stream().mapToInt(List::size).sum());
 	}
 
@@ -52,11 +52,11 @@ public class InteractiveEditingTest {
 		MainApplication.getLayerManager().addLayer(matsimLayer);
 		Node node1 = new Node();
 		node1.setCoor(new LatLon(0.0, 0.0));
-		AddCommand addNode1 = new AddCommand(matsimLayer, node1);
+		AddCommand addNode1 = new AddCommand(matsimLayer.data, node1);
 		addNode1.executeCommand();
 		Node node2 = new Node();
 		node2.setCoor(new LatLon(0.1, 0.1));
-		AddCommand addNode2 = new AddCommand(matsimLayer, node2);
+		AddCommand addNode2 = new AddCommand(matsimLayer.data, node2);
 		addNode2.executeCommand();
 		Way way = new Way();
 		way.addNode(node1);
@@ -65,7 +65,7 @@ public class InteractiveEditingTest {
 		way.put(LinkConversionRules.CAPACITY, "1000.0");
 		way.put(LinkConversionRules.PERMLANES, "1.0");
 		way.put(LinkConversionRules.MODES, "car");
-		AddCommand addWay = new AddCommand(matsimLayer, way);
+		AddCommand addWay = new AddCommand(matsimLayer.data, way);
 		addWay.executeCommand();
 		Assert.assertEquals(1, matsimLayer.getNetworkModel().getWay2Links().values().stream().mapToInt(List::size).sum());
 		Assert.assertEquals(2, matsimLayer.getNetworkModel().nodes().size());
@@ -84,10 +84,10 @@ public class InteractiveEditingTest {
 		MainApplication.getLayerManager().addLayer(matsimLayer);
 		Node node1 = new Node();
 		node1.setCoor(new LatLon(0.0, 0.0));
-		new AddCommand(matsimLayer, node1).executeCommand();
+		new AddCommand(matsimLayer.data, node1).executeCommand();
 		Node node2 = new Node();
 		node2.setCoor(new LatLon(0.1, 0.1));
-		new AddCommand(matsimLayer, node2).executeCommand();
+		new AddCommand(matsimLayer.data, node2).executeCommand();
 		Way way = new Way();
 		way.addNode(node1);
 		way.addNode(node2);
@@ -95,7 +95,7 @@ public class InteractiveEditingTest {
 		way.put(LinkConversionRules.CAPACITY, "1000.0");
 		way.put(LinkConversionRules.PERMLANES, "1.0");
 		way.put(LinkConversionRules.MODES, "car");
-		new AddCommand(matsimLayer, way).executeCommand();
+		new AddCommand(matsimLayer.data, way).executeCommand();
 		DeleteCommand delete = new DeleteCommand(way);
 		delete.executeCommand();
 		delete.undoCommand();
@@ -108,10 +108,10 @@ public class InteractiveEditingTest {
 		MainApplication.getLayerManager().addLayer(matsimLayer);
 		Node node1 = new Node();
 		node1.setCoor(new LatLon(0.0, 0.0));
-		new AddCommand(matsimLayer, node1).executeCommand();
+		new AddCommand(matsimLayer.data, node1).executeCommand();
 		Node node2 = new Node();
 		node2.setCoor(new LatLon(0.1, 0.1));
-		new AddCommand(matsimLayer, node2).executeCommand();
+		new AddCommand(matsimLayer.data, node2).executeCommand();
 		Way way = new Way();
 		way.addNode(node1);
 		way.addNode(node2);
@@ -119,7 +119,7 @@ public class InteractiveEditingTest {
 		way.put(LinkConversionRules.CAPACITY, "1000.0");
 		way.put(LinkConversionRules.PERMLANES, "1.0");
 		way.put(LinkConversionRules.MODES, "car");
-		new AddCommand(matsimLayer, way).executeCommand();
+		new AddCommand(matsimLayer.data, way).executeCommand();
 		DeleteCommand deleteWay = new DeleteCommand(way);
 		deleteWay.executeCommand();
 		Assert.assertEquals(0, matsimLayer.getNetworkModel().getWay2Links().values().stream().mapToInt(List::size).sum());
@@ -143,14 +143,14 @@ public class InteractiveEditingTest {
 		MainApplication.getLayerManager().addLayer(matsimLayer);
 		Node node1 = new Node();
 		node1.setCoor(new LatLon(0.0, 0.0));
-		new AddCommand(matsimLayer, node1).executeCommand();
+		new AddCommand(matsimLayer.data, node1).executeCommand();
 		Node node2 = new Node();
 		node2.setCoor(new LatLon(0.1, 0.1));
-		new AddCommand(matsimLayer, node2).executeCommand();
+		new AddCommand(matsimLayer.data, node2).executeCommand();
 		Way way = new Way();
 		way.addNode(node1);
 		way.addNode(node2);
-		new AddCommand(matsimLayer, way).executeCommand();
+		new AddCommand(matsimLayer.data, way).executeCommand();
 		Assert.assertEquals(0, matsimLayer.getNetworkModel().getWay2Links().values().stream().mapToInt(List::size).sum());
 		new ChangePropertyCommand(way, LinkConversionRules.FREESPEED, "10.0").executeCommand();
 		new ChangePropertyCommand(way, LinkConversionRules.CAPACITY, "1000.0").executeCommand();

--- a/src/test/java/org/matsim/contrib/josm/OSMDataTest.java
+++ b/src/test/java/org/matsim/contrib/josm/OSMDataTest.java
@@ -51,7 +51,7 @@ public class OSMDataTest {
 
 	@Before
 	public void init() throws IOException, IllegalDataException {
-		org.openstreetmap.josm.spi.preferences.Config.getPref().putBoolean("matsim_supportTransit", true);
+		Preferences.setSupportTransit(true);
 		URL urlIncompleteWay = getClass().getResource("/test-input/OSMData/incompleteWay.osm.xml");
 		URL urlRoute = getClass().getResource("/test-input/OSMData/busRoute.osm.xml");
 		URL urlIntersections = getClass().getResource("/test-input/OSMData/loops_intersecting_ways.osm.xml");

--- a/src/test/java/org/matsim/contrib/josm/OSMDataTest.java
+++ b/src/test/java/org/matsim/contrib/josm/OSMDataTest.java
@@ -14,7 +14,6 @@ import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.command.ChangeNodesCommand;
 import org.openstreetmap.josm.command.Command;
 import org.openstreetmap.josm.command.DeleteCommand;
@@ -52,7 +51,7 @@ public class OSMDataTest {
 
 	@Before
 	public void init() throws IOException, IllegalDataException {
-		Main.pref.put("matsim_supportTransit", true);
+		org.openstreetmap.josm.spi.preferences.Config.getPref().putBoolean("matsim_supportTransit", true);
 		URL urlIncompleteWay = getClass().getResource("/test-input/OSMData/incompleteWay.osm.xml");
 		URL urlRoute = getClass().getResource("/test-input/OSMData/busRoute.osm.xml");
 		URL urlIntersections = getClass().getResource("/test-input/OSMData/loops_intersecting_ways.osm.xml");
@@ -85,7 +84,7 @@ public class OSMDataTest {
 
 	@Test
 	public void testWayNodesChanged() {
-		Main.pref.put("matsim_keepPaths", true);
+		org.openstreetmap.josm.spi.preferences.Config.getPref().putBoolean("matsim_keepPaths", true);
 		Way way = incompleteWayLayer.data.getWays().iterator().next();
 		List<Node> nodes = new ArrayList<>();
 		for (Node node: incompleteWayLayer.data.getNodes()) {
@@ -145,7 +144,7 @@ public class OSMDataTest {
 			Assert.assertEquals(5, route.getRoute().size());
 		}
 
-		Main.pref.put("matsim_keepPaths", true);
+		org.openstreetmap.josm.spi.preferences.Config.getPref().putBoolean("matsim_keepPaths", true);
 		Assert.assertEquals(18,busRouteListener.getWay2Links().values().stream().mapToInt(List::size).sum());
 		Assert.assertEquals(10,busRouteListener.nodes().size());
 		Assert.assertEquals(4,busRouteListener.stopAreas().size());
@@ -165,7 +164,7 @@ public class OSMDataTest {
 		}
 		Assert.assertEquals(1, nStopsWithLink);
 
-		Main.pref.put("matsim_keepPaths", false);
+		org.openstreetmap.josm.spi.preferences.Config.getPref().putBoolean("matsim_keepPaths", false);
 		Assert.assertEquals(10,busRouteListener.getWay2Links().values().stream().mapToInt(List::size).sum());
 		Assert.assertEquals(6,busRouteListener.nodes().size());
 		Assert.assertEquals(4,busRouteListener.stopAreas().size());
@@ -210,7 +209,7 @@ public class OSMDataTest {
 		 Assert.assertEquals(11,intersectionsListener.getWay2Links().values().stream().mapToInt(List::size).sum());
 		 Assert.assertEquals(12,intersectionsListener.nodes().size());
 
-		 Command delete = DeleteCommand.delete(intersectionsLayer, Collections.singleton(intersectionsLayer.data.getPrimitiveById(14, OsmPrimitiveType.NODE)), false, true);
+		 Command delete = DeleteCommand.delete(Collections.singleton(intersectionsLayer.data.getPrimitiveById(14, OsmPrimitiveType.NODE)), false, true);
 		 delete.executeCommand();
 		 Assert.assertEquals(9,intersectionsListener.getWay2Links().values().stream().mapToInt(List::size).sum());
 		 Assert.assertEquals(11,intersectionsListener.nodes().size());
@@ -219,7 +218,7 @@ public class OSMDataTest {
 		 Assert.assertEquals(11,intersectionsListener.getWay2Links().values().stream().mapToInt(List::size).sum());
 		 Assert.assertEquals(12,intersectionsListener.nodes().size());
 
-		 Command delete2 = DeleteCommand.delete(intersectionsLayer, Collections.singleton(intersectionsLayer.data.getPrimitiveById(2, OsmPrimitiveType.NODE)), false, true);
+		 Command delete2 = DeleteCommand.delete(Collections.singleton(intersectionsLayer.data.getPrimitiveById(2, OsmPrimitiveType.NODE)), false, true);
 		 delete2.executeCommand();
 		 Assert.assertEquals(10,intersectionsListener.getWay2Links().values().stream().mapToInt(List::size).sum());
 		 Assert.assertEquals(12,intersectionsListener.nodes().size());
@@ -228,7 +227,7 @@ public class OSMDataTest {
 		 Assert.assertEquals(11,intersectionsListener.getWay2Links().values().stream().mapToInt(List::size).sum());
 		 Assert.assertEquals(12,intersectionsListener.nodes().size());
 
-		 Command delete3 = DeleteCommand.delete(intersectionsLayer, Collections.singleton(intersectionsLayer.data.getPrimitiveById(3, OsmPrimitiveType.WAY)), false, true);
+		 Command delete3 = DeleteCommand.delete(Collections.singleton(intersectionsLayer.data.getPrimitiveById(3, OsmPrimitiveType.WAY)), false, true);
 		 delete3.executeCommand();
 		 Assert.assertEquals(8,intersectionsListener.getWay2Links().values().stream().mapToInt(List::size).sum());
 		 Assert.assertEquals(9,intersectionsListener.nodes().size());

--- a/src/test/java/org/matsim/contrib/josm/ProjectionHandlingTest.java
+++ b/src/test/java/org/matsim/contrib/josm/ProjectionHandlingTest.java
@@ -3,18 +3,16 @@ package org.matsim.contrib.josm;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.matsim.api.core.v01.Coord;
-import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.network.Node;
 import org.matsim.contrib.josm.model.MATSimLayer;
 import org.matsim.contrib.josm.model.MNode;
 import org.openstreetmap.josm.Main;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.preferences.projection.ProjectionPreference;
 import org.openstreetmap.josm.testutils.JOSMTestRules;
 
@@ -41,7 +39,7 @@ public class ProjectionHandlingTest {
 	@Test
 	public void test() {
 		
-		Main.getLayerManager().addLayer(matsimLayer);
+		MainApplication.getLayerManager().addLayer(matsimLayer);
 		
 		Assert.assertEquals(ProjectionPreference.mercator.getProjection().toCode(), Main.getProjection().toCode());
 		Main.setProjection(ProjectionPreference.wgs84.getProjection());

--- a/src/test/java/org/matsim/contrib/josm/UpdateStopTagsTest.java
+++ b/src/test/java/org/matsim/contrib/josm/UpdateStopTagsTest.java
@@ -13,6 +13,7 @@ import org.openstreetmap.josm.command.Command;
 import org.openstreetmap.josm.data.coor.LatLon;
 import org.openstreetmap.josm.data.osm.*;
 import org.openstreetmap.josm.data.validation.TestError;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
 import org.openstreetmap.josm.testutils.JOSMTestRules;
 
@@ -21,7 +22,7 @@ import java.lang.reflect.InvocationTargetException;
 public class UpdateStopTagsTest {
 
 	@Rule
- 	public JOSMTestRules test = new JOSMTestRules().preferences();;
+	public JOSMTestRules test = new JOSMTestRules().preferences();
 
 	private OsmDataLayer layer;
 
@@ -49,7 +50,7 @@ public class UpdateStopTagsTest {
 		config.transit().setUseTransit(true);
 		NetworkModel listener = NetworkModel.createNetworkModel(data);
 		listener.visitAll();
-		Main.getLayerManager().addLayer(layer);
+		MainApplication.getLayerManager().addLayer(layer);
 	}
 
 	private void initializeDataSet(DataSet data) {

--- a/src/test/java/org/matsim/contrib/josm/UpdateStopTagsTest.java
+++ b/src/test/java/org/matsim/contrib/josm/UpdateStopTagsTest.java
@@ -8,7 +8,6 @@ import org.matsim.contrib.josm.model.NetworkModel;
 import org.matsim.contrib.osm.UpdateStopTags;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.command.Command;
 import org.openstreetmap.josm.data.coor.LatLon;
 import org.openstreetmap.josm.data.osm.*;
@@ -42,7 +41,7 @@ public class UpdateStopTagsTest {
 
 	@Before
 	public void init() {
-		Main.pref.put("matsim_supportTransit", true);
+		org.openstreetmap.josm.spi.preferences.Config.getPref().putBoolean("matsim_supportTransit", true);
 		DataSet data = new DataSet();
 		initializeDataSet(data);
 		layer = new OsmDataLayer(data, "test", null);

--- a/src/test/java/org/matsim/contrib/josm/UpdateStopTagsTest.java
+++ b/src/test/java/org/matsim/contrib/josm/UpdateStopTagsTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.matsim.contrib.josm.gui.Preferences;
 import org.matsim.contrib.josm.model.NetworkModel;
 import org.matsim.contrib.osm.UpdateStopTags;
 import org.matsim.core.config.Config;
@@ -41,7 +42,7 @@ public class UpdateStopTagsTest {
 
 	@Before
 	public void init() {
-		org.openstreetmap.josm.spi.preferences.Config.getPref().putBoolean("matsim_supportTransit", true);
+		Preferences.setSupportTransit(true);
 		DataSet data = new DataSet();
 		initializeDataSet(data);
 		layer = new OsmDataLayer(data, "test", null);


### PR DESCRIPTION
This pull request replaces calls to deprecated API methods or methods that have already been removed from the API.

All of these changes are also included in #64, so if you apply that PR, you don't need this one.

You'll need to adjust the unit tests, because the version of the [JOSM testutils](https://github.com/matsim-org/josm-matsim-plugin/tree/2ae48f23e3e8a1f57571cda64f0115f44fb31ef9/src/test/java/org/openstreetmap/josm) that you use is out of date. Otherwise this pull request fixes most of #65.
In PR #64 I fixed the problem with the outdated JOSM testutils, by using the automatically updated [`josm-unittest.jar`](https://josm.openstreetmap.de/download/josm-unittest.jar) artifact.