### PR TITLE
Bump josmCompileVersion to 13025

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ sourceCompatibility = 1.8
 version = gitVersion().replace('.dirty', '-dirty')
 archivesBaseName = "matsim"
 josm {
-    josmCompileVersion = 12885
+    josmCompileVersion = 13025
     manifest {
         author = "Nico Kuehnel"
         description = "Allows to edit and extract network information for the traffic simulation MATSim"


### PR DESCRIPTION
That's because the code signing certificate changed on 2017-10-06, so it was different for the dependency on `josm` and on `josm-unittest`.

See #67.