### PR TITLE
Release the plugin with the right version number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,16 @@ matrix:
   fast_finish: true
   allow_failures:
   - jdk: oraclejdk9
+
+deploy:
+  provider: releases
+  file_glob: true
+  api_key: "${GH_TOKEN}"
+  file:
+    - "build/dist/matsim.jar"
+    - "build/tmp/jar/MANIFEST.MF"
+  skip_cleanup: true
+  on:
+    condition: -n $GH_TOKEN
+    tags: true
+    jdk: oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-    id 'com.palantir.git-version' version '0.9.1'
-    id 'org.openstreetmap.josm' version '0.2.1'
+    id 'org.openstreetmap.josm' version '0.2.2'
     id 'java'
     id 'eclipse'
     id 'idea'
@@ -50,8 +49,9 @@ sourceSets {
 }
 
 sourceCompatibility = 1.8
-
-version = gitVersion().replace('.dirty', '-dirty')
+def gitVersion = ['git', 'describe', '--always', '--tags', '--dirty'].execute()
+gitVersion.waitFor()
+version = gitVersion.in.text.trim()
 archivesBaseName = "matsim"
 josm {
     josmCompileVersion = 13170


### PR DESCRIPTION
The last two releases are appearing in JOSM with a wrong version number (`v0.8.4` as `v0.8.3-3-gfaca0ec`, `v0.8.5` as `v0.7.8-15-gf75deaf-dirty`).

That's probably because the git-tag wasn't present on your machine when building the released *.jar file.

This PR proposes to automate the process of releasing. This also ensures that all published git-tags are present when building.
You just need to create a [Personal Access Token](https://github.com/settings/tokens), add the token to the [environment variables of Travis CI](https://travis-ci.org/matsim-org/josm-matsim-plugin/settings) as `GH_TOKEN` and as soon as you push the next git-tag, Travis CI will automatically create a GitHub release for you containing the resulting *.jar file.

Another thing I changed, was how the version number is determined. I removed the Gradle plugin `git-version`, because three lines of Groovy can do the same.