### PR TITLE
Update GTFS-lib from v1.1.0 to v5.0.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,6 @@ dependencies {
     packIntoJar ('org.matsim:matsim:11.0') {changing = true}
     packIntoJar ('org.matsim.contrib:otfvis:11.0') {changing = true}
     packIntoJar ('org.matsim.contrib:emissions:11.0') {changing = true}
-    packIntoJar ('org.geotools:gt-shapefile:20.2')
-    packIntoJar ('org.geotools:gt-opengis:20.2')
-    packIntoJar ('org.geotools:gt-referencing:20.2')
     packIntoJar ('com.github.conveyal:gtfs-lib:v1.1.0')
 
     def junitVersion = "5.2.0"
@@ -59,7 +56,7 @@ josm {
         iconPath = "images/dialogs/matsim-scenario.png"
         minJosmVersion = 15238
         mainClass = "org.matsim.contrib.josm.MATSimPlugin"
-        pluginDependencies << 'jts' << 'javafx'
+        pluginDependencies << 'jts' << 'javafx' << 'geotools'
         website = new URL("http://www.matsim.org")
         oldVersionDownloadLink 15007, 'v1.0.3', new URL('https://github.com/matsim-org/josm-matsim-plugin/releases/download/v1.0.3/matsim.jar')
         oldVersionDownloadLink 14418, 'v1.0.0', new URL('https://github.com/matsim-org/josm-matsim-plugin/releases/download/v1.0.0/matsim.jar')

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.openstreetmap.josm' version '0.6.1'
+    id 'org.openstreetmap.josm' version '0.6.4'
     id 'java'
     id 'eclipse'
     id 'idea'
@@ -9,47 +9,59 @@ plugins {
 // local Maven cache. We use it to get the MATSim snapshot.
 repositories {
     maven {
-        url 'http://dl.bintray.com/matsim/matsim'
+        url("https://dl.bintray.com/matsim/matsim")
+        content {
+            includeGroup("org.matsim")
+            includeGroup("org.matsim.contrib")
+        }
     }
     maven {
-        url 'http://download.osgeo.org/webdav/geotools'
+        // This repository is only needed for GeoTools dependencies that are not excluded when compiling against minJosm/latestJosm/testedJosm in gradle-josm-plugin <= 0.6.4.
+        // As soon as a new version of that plugin is released, this `maven{}` block can be removed
+        url("https://download.osgeo.org/webdav/geotools")
+        content {
+            includeGroup("javax.media")
+            includeGroup("jgridshift")
+            includeGroup("org.geotools")
+        }
     }
     maven {
-        url 'https://oss.jfrog.org/artifactory/libs-snapshot'
+        url("https://maven.conveyal.com")
+        content {
+            includeGroup("com.conveyal")
+        }
     }
-    maven {
-        url 'https://jitpack.io'
-    }
+    jcenter()
 }
 
 // Use the `packIntoJar` configuration from gradle-josm-plugin for our external dependency (MATSim), whose classes get zipped into our jar.
-configurations {
-    packIntoJar.exclude(group: 'kml')
-    packIntoJar.exclude(group: 'org.jfree')
-    packIntoJar.exclude(group: 'commons-logging')
-    packIntoJar.exclude(group: 'commons-io')
-    packIntoJar.exclude(group: 'org.apache.httpcomponents')
+configurations.packIntoJar {
+    exclude(group: 'org.geotools')
+    exclude(group: 'org.jfree')
+    exclude(group: 'commons-logging')
+    exclude(group: 'commons-io')
+    exclude(group: 'org.apache.httpcomponents')
 }
 
 dependencies {
     packIntoJar ('org.matsim:matsim:11.0') {changing = true}
     packIntoJar ('org.matsim.contrib:otfvis:11.0') {changing = true}
     packIntoJar ('org.matsim.contrib:emissions:11.0') {changing = true}
-    packIntoJar ('com.github.conveyal:gtfs-lib:v1.1.0')
+    packIntoJar ('com.conveyal:gtfs-lib:5.0.7')
 
-    def junitVersion = "5.2.0"
+    def junitVersion = "5.5.2"
     testImplementation ("org.junit.jupiter:junit-jupiter-api:$junitVersion")
     testRuntimeOnly ("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
     testImplementation ("org.junit.vintage:junit-vintage-engine:$junitVersion")
-    testImplementation ('org.openstreetmap.josm:josm-unittest:') {changing = true}
-    testImplementation ("com.github.tomakehurst:wiremock:2.18.0")
-    testImplementation ("org.awaitility:awaitility:3.1.2")
+    testImplementation ('org.openstreetmap.josm:josm-unittest:SNAPSHOT') {changing = true}
+    testImplementation ("com.github.tomakehurst:wiremock:2.25.1")
+    testImplementation ("org.awaitility:awaitility:4.0.1")
 }
 
 sourceCompatibility = 1.8
 archivesBaseName = "matsim"
 josm {
-    josmCompileVersion = 15238
+    josmCompileVersion = 15492
     manifest {
         author = "Nico Kuehnel"
         description = "Allows to edit and extract network information for the traffic simulation MATSim"

--- a/src/main/java/org/matsim/contrib/josm/model/Export.java
+++ b/src/main/java/org/matsim/contrib/josm/model/Export.java
@@ -15,8 +15,6 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
-
-import org.matsim.contrib.emissions.EmissionUtils;
 import org.matsim.contrib.josm.gui.Preferences;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;

--- a/src/main/java/org/matsim/contrib/josm/model/StopArea.java
+++ b/src/main/java/org/matsim/contrib/josm/model/StopArea.java
@@ -3,7 +3,14 @@ package org.matsim.contrib.josm.model;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.vividsolutions.jts.geom.Geometry;
+import javafx.beans.property.ListProperty;
+import javafx.beans.property.SimpleListProperty;
+import javafx.collections.FXCollections;
+
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
@@ -14,14 +21,6 @@ import org.openstreetmap.josm.data.osm.OsmPrimitive;
 import org.openstreetmap.josm.data.osm.Relation;
 import org.openstreetmap.josm.data.osm.RelationMember;
 import org.openstreetmap.josm.data.projection.ProjectionRegistry;
-
-import com.vividsolutions.jts.geom.GeometryCollection;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.Point;
-
-import javafx.beans.property.ListProperty;
-import javafx.beans.property.SimpleListProperty;
-import javafx.collections.FXCollections;
 import org.openstreetmap.josm.plugins.jts.JTSConverter;
 
 public class StopArea {
@@ -87,7 +86,7 @@ public class StopArea {
 			}
 		}
 
-		com.vividsolutions.jts.geom.Geometry[] geometries = nodes.stream().map(prim -> new JTSConverter().convert(prim)).toArray(Geometry[]::new);
+		Geometry[] geometries = nodes.stream().map(prim -> new JTSConverter().convert(prim)).toArray(Geometry[]::new);
 		GeometryCollection geometryCollection = new GeometryCollection(geometries, new GeometryFactory());
 		Point centroid = geometryCollection.getCentroid();
 		if (centroid.isEmpty()) {

--- a/src/main/po/de.po
+++ b/src/main/po/de.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'matsim' (de)
-# Copyright (C) 2018 
+# Copyright (C) 2019
 # This file is distributed under the same license as the josm-plugin_matsim package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_matsim v0.9.3-1-g5f14357\n"
+"Project-Id-Version: josm-plugin_matsim 0.8.7-55-g88e42cd\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-26 15:50+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2019-08-26 09:01+0000\n"
+"PO-Revision-Date: 2018-05-23 08:43+0000\n"
 "Language-Team: German (https://www.transifex.com/josm/teams/2544/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,7 +17,6 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#. Visualization
 msgid "Activate MATSim Renderer"
 msgstr "MATSim-Renderer aktivieren"
 
@@ -51,6 +50,9 @@ msgstr "Zu MATSim-Netzwerk konvertieren"
 msgid "Converter"
 msgstr "Konverter"
 
+msgid "Create areas for public transport stops"
+msgstr "Erzeuge Flächen für ÖPNV-Haltepunkte"
+
 msgid "Create new Network"
 msgstr "Neues Netzwerk erzeugen"
 
@@ -73,18 +75,29 @@ msgstr "Von der Overpass API herunterladen…"
 msgid "Download members and stop areas"
 msgstr "Lade Mitglieder und Haltestellenbereiche herunter"
 
-#. create error with message
-#. create warning with message
-#, java-format
 msgid "Duplicated Id {0} not allowed."
 msgstr "Doppelte ID {0} ist nicht erlaubt."
+
+msgid "Export MATSim network to shape file..."
+msgstr "Exportiere MATSim-Netzwerk als Shapefile…"
+
+msgid "Export MATSim network to shape file…"
+msgstr "Exportiere MATSim-Netzwerk als Shapefile…"
 
 msgid "Export MATSim transit schedule…"
 msgstr "Den MATSim Transit-Ablaufplan exportieren…"
 
-#. General
+msgid ""
+"Export failed due to validation errors. See validation layer for details."
+msgstr ""
+"Der Export ist fehlgeschlagen, weil es bei der Validierung zu Fehlern kam. "
+"Siehe Validierungs-Ebene für Details."
+
 msgid "Exported network xml version"
 msgstr "Version des exportierten XML-Netzwerks"
+
+msgid "Failure"
+msgstr "Fehler"
 
 msgid "Fix transit schedule validation errors"
 msgstr "Fehler in den Prüfergebnissen für Transit-Ablaufpläne beheben"
@@ -104,14 +117,12 @@ msgstr "Straßentyp soll in der Ausgabe enthalten sein"
 msgid "Information"
 msgstr "Information"
 
-#, java-format
 msgid "Lines: {0} / Routes: {1}"
 msgstr "Linien: {0} / Routen: {1}"
 
 msgid "Links/Nodes"
 msgstr "Kanten/Knoten"
 
-#, java-format
 msgid "Links: {0} / Nodes: {1}"
 msgstr "Kanten: {0} / Knoten: {1}"
 
@@ -127,7 +138,6 @@ msgstr "MATSim-Import"
 msgid "MATSimValidation"
 msgstr "MATSimValidierung"
 
-#, java-format
 msgid "Menu: {0}"
 msgstr "Menü: {0}"
 
@@ -152,13 +162,11 @@ msgstr "Hierarchien nur konvertieren bis höchstens:"
 msgid "Save MATSim network file"
 msgstr "MATSim Netzwerk-Datei speichern"
 
-#, java-format
 msgid "Select to download {0} highways in the selected download area."
 msgstr ""
 "Auswählen, um {0} Straßen im ausgewählten Herunterladebereich "
 "herunterzuladen."
 
-#, java-format
 msgid "Select to download {0} routes in the selected download area."
 msgstr ""
 "Auswählen, um {0} Routen im ausgewählten Herunterladebereich "
@@ -170,7 +178,6 @@ msgstr "Interne IDs in Tabelle anzeigen"
 msgid "Simulate"
 msgstr "Simulieren"
 
-#. Converter
 msgid "Transit support [alpha]"
 msgstr "Transit-Unterstützung [alpha]"
 
@@ -197,7 +204,6 @@ msgstr "Warnung"
 msgid "edit network attributes"
 msgstr "Netzwerk-Attribute bearbeiten"
 
-#. Plugin description for josm-matsim-plugin
 msgid ""
 "Allows to edit and extract network information for the traffic simulation "
 "MATSim"

--- a/src/main/po/el.po
+++ b/src/main/po/el.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'matsim' (el)
-# Copyright (C) 2018 
+# Copyright (C) 2019
 # This file is distributed under the same license as the josm-plugin_matsim package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_matsim v0.9.3-1-g5f14357\n"
+"Project-Id-Version: josm-plugin_matsim 0.8.7-55-g88e42cd\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-26 15:50+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2019-08-26 09:01+0000\n"
+"PO-Revision-Date: 2018-05-23 08:43+0000\n"
 "Language-Team: Greek (https://www.transifex.com/josm/teams/2544/el/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,7 +17,6 @@ msgstr ""
 "Language: el\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#. Visualization
 msgid "Activate MATSim Renderer"
 msgstr "Ενεργοποίηση της Απόδοσης MATSim"
 
@@ -26,6 +25,9 @@ msgstr "Ενεργοποίηση του φίλτρου ιεραρχίας"
 
 msgid "Check for Incomplete Routes"
 msgstr "Έλεγχος για ημιτελείς Διαδρομές"
+
+msgid "Clean Network"
+msgstr "Καθαρό δίκτυο"
 
 msgid "Click to download the currently selected area"
 msgstr "Κάντε κλικ για λήψη της τρέχουσας επιλεγμένης περιοχής"
@@ -77,9 +79,6 @@ msgstr "Λήψη από το Overpass API..."
 msgid "Download members and stop areas"
 msgstr "Λήψη μελών και χώροι στάσεων"
 
-#. create error with message
-#. create warning with message
-#, java-format
 msgid "Duplicated Id {0} not allowed."
 msgstr "Διπλό αναγνωριστικό {0} δεν επιτρέπεται."
 
@@ -98,7 +97,6 @@ msgstr ""
 "Η εξαγωγή απέτυχε λόγω σφαλμάτων επικύρωσης. Δείτε το επίπεδο επικύρωσης για"
 " λεπτομέρειες."
 
-#. General
 msgid "Exported network xml version"
 msgstr "Εξαγόμενη έκδοση δικτύου xml"
 
@@ -120,7 +118,6 @@ msgstr "Εισαγωγή σεναρίου MATSim"
 msgid "Include road type in output"
 msgstr "Συμπεριλάβετε τον τύπο δρόμου στην έξοδο"
 
-#, java-format
 msgid ""
 "Incomplete route {0} - Auto repair to download missing elements (cannot be "
 "undone)"
@@ -134,7 +131,6 @@ msgstr "Πληροφορίες"
 msgid "Keep Paths"
 msgstr "Διατήρηση Διαδρομών"
 
-#, java-format
 msgid "Lines: {0} / Routes: {1}"
 msgstr "Γραμμές: {0} / Διαδρομές: {1}"
 
@@ -144,7 +140,6 @@ msgstr "Μετατόπιση συνδέσμου για επικαλυπτόμε�
 msgid "Links/Nodes"
 msgstr "Σύνδεσμοι/Κόμβοι"
 
-#, java-format
 msgid "Links: {0} / Nodes: {1}"
 msgstr "Σύνδεσμοι: {0} / Κόμβοι: {1}"
 
@@ -163,7 +158,6 @@ msgstr "Αρχεία Προγραμματισμού Μεταφοράς MATSim"
 msgid "MATSimValidation"
 msgstr "Επικύρωση MATSim"
 
-#, java-format
 msgid "Menu: {0}"
 msgstr "Μενού: {0}"
 
@@ -185,19 +179,16 @@ msgstr "Επισκευή OSM"
 msgid "Only convert hierarchies up to: "
 msgstr "Μετατρέψτε μόνο ιεραρχίες μέχρι:"
 
-#, java-format
 msgid "Route {0} with no Route Master"
 msgstr "Διαδρομή {0} χωρίς Κύρια Διαδρομή"
 
 msgid "Save MATSim network file"
 msgstr "Αποθήκευση του αρχείου δικτύου MATSim"
 
-#, java-format
 msgid "Select to download {0} highways in the selected download area."
 msgstr ""
 "Επιλέξτε για να κάνετε λήψη {0} δρόμους στην επιλεγμένη περιοχή λήψης."
 
-#, java-format
 msgid "Select to download {0} routes in the selected download area."
 msgstr ""
 "Επιλέξτε για να κάνετε λήψη {0} διαδρομών στην επιλεγμένη περιοχή λήψης."
@@ -213,6 +204,9 @@ msgstr "Δοκιμή για ημιτελείς διαδρομές"
 
 msgid "Test for master routes"
 msgstr "Δοκιμή για κύριες διαδρομές"
+
+msgid "Update tags for public transport stops"
+msgstr "Ενημέρωση ετικετών για στάσεις μαζικής μεταφοράς"
 
 msgid "Visualization"
 msgstr "Οπτικοποίηση"

--- a/src/main/po/hu.po
+++ b/src/main/po/hu.po
@@ -1,0 +1,136 @@
+# Translations for the JOSM plugin 'matsim' (hu)
+# Copyright (C) 2019
+# This file is distributed under the same license as the josm-plugin_matsim package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: josm-plugin_matsim 0.8.7-55-g88e42cd\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-08-26 09:01+0000\n"
+"PO-Revision-Date: 2018-05-23 08:43+0000\n"
+"Language-Team: Hungarian (https://www.transifex.com/josm/teams/2544/hu/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: hu\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Activate MATSim Renderer"
+msgstr "MATSim megjelenítő aktiválása"
+
+msgid "Activate hierarchy filter"
+msgstr "Hierarchiaszűrő aktiválása"
+
+msgid "Check for Incomplete Routes"
+msgstr "Hiányos útvonalak keresése"
+
+msgid "Clean Network"
+msgstr "Hálózat tisztítása"
+
+msgid "Click to download the currently selected area"
+msgstr "Kattints a kijelölt terület letöltéséhez"
+
+msgid "Configure the MATSim plugin."
+msgstr "A MATSim beépülő modul beállításai"
+
+msgid "Contacting OSM Server..."
+msgstr "Kapcsolódás az OSM szerverhez..."
+
+msgid "Convert Osm layer to MATSim network layer"
+msgstr "OSM-réteg konvertálása MATSim hálózati réteggé"
+
+msgid "Convert to MATSim Layer"
+msgstr "MATSim réteggé konvertálás"
+
+msgid "Convert to MATSim Network"
+msgstr "MATSim hálózattá konvertálás"
+
+msgid "Converter"
+msgstr "Konvertáló"
+
+msgid "Create areas for public transport stops"
+msgstr "Területek létrehozása tömegközlekedési megállókhoz"
+
+msgid "Create new Network"
+msgstr "Új hálózat létrehozása"
+
+msgid "Defaults"
+msgstr "Alapértelmezettek"
+
+msgid "Download"
+msgstr "Letöltés"
+
+msgid "Download VBB…"
+msgstr "VBB letöltése..."
+
+msgid "Download data from Overpass API, filtered by relevance for MATSim."
+msgstr ""
+"Adatok letöltése Overpass API-val, fontosság szerint szűrve MATSim számára."
+
+msgid "Download from Overpass API..."
+msgstr "Letöltés Overpass API-n keresztül"
+
+msgid "Duplicated Id {0} not allowed."
+msgstr "Dupla azonosító {0} nincs megengedve."
+
+msgid "Exported network xml version"
+msgstr "Hálózati XML fájl exportálva"
+
+msgid "Failure"
+msgstr "Hiba"
+
+msgid "Import"
+msgstr "Importálás"
+
+msgid "Information"
+msgstr "Információ"
+
+msgid "Lines: {0} / Routes: {1}"
+msgstr "Vonal: {0} / útvonal: {1}"
+
+msgid "MASim preferences"
+msgstr "MASim beállítások"
+
+msgid "MATSim"
+msgstr "MATSim"
+
+msgid "MATSim Import"
+msgstr "MATSim Import"
+
+msgid "Menu: {0}"
+msgstr "Menü: {0}"
+
+msgid "Network Attributes"
+msgstr "Hálózati tulajdonságok"
+
+msgid "New MATSim network"
+msgstr "Új MATSim hálózat"
+
+msgid "No MATSim layer active"
+msgstr "Nincs aktív MATSim réteg"
+
+msgid "Nothing to export. Get some data first."
+msgstr "Nincs mit exportálni. Először szerezz néhány adatot."
+
+msgid "Save MATSim network file"
+msgstr "MATSim hálózati fájl mentése"
+
+msgid "Set conversion defaults"
+msgstr "Alapértelmezett konvertálási beállítások"
+
+msgid "Simulate"
+msgstr "Szimuláció"
+
+msgid "Test for incomplete routes"
+msgstr "Hiányos útvonalak tesztelése"
+
+msgid "Visualization"
+msgstr "Megjelenítés"
+
+msgid "Warning"
+msgstr "Figyelmeztetés"
+
+msgid "edit network attributes"
+msgstr "Hálózati tulajdonságok szerkesztése"

--- a/src/main/po/it.po
+++ b/src/main/po/it.po
@@ -1,21 +1,33 @@
 # Translations for the JOSM plugin 'matsim' (it)
-# Copyright (C) 2018 
+# Copyright (C) 2019
 # This file is distributed under the same license as the josm-plugin_matsim package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_matsim v0.9.3-1-g5f14357\n"
+"Project-Id-Version: josm-plugin_matsim 0.8.7-55-g88e42cd\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-26 15:50+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2019-08-26 09:01+0000\n"
+"PO-Revision-Date: 2018-05-23 08:43+0000\n"
 "Language-Team: Italian (https://www.transifex.com/josm/teams/2544/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Activate MATSim Renderer"
+msgstr "Attiva MATSim Renderer"
+
+msgid "Activate hierarchy filter"
+msgstr "Attiva il filtro gerarchico"
+
+msgid "Check for Incomplete Routes"
+msgstr "Verifica le Rotte Incomplete"
+
+msgid "Clean Network"
+msgstr "Pulisci Rete"
 
 msgid "Click to download the currently selected area"
 msgstr "Clicca per scaricare l''area attualmente selezionata"
@@ -38,6 +50,12 @@ msgstr "Converti in una rete MATSim"
 msgid "Converter"
 msgstr "Convertitore"
 
+msgid "Create Master Routes"
+msgstr "Crea itinerari master"
+
+msgid "Create areas for public transport stops"
+msgstr "Crea aree per fermate del trasporto pubblico"
+
 msgid "Create new Network"
 msgstr "Crea una nuova rete"
 
@@ -47,12 +65,42 @@ msgstr "Predefiniti"
 msgid "Download"
 msgstr "Scarica"
 
+msgid "Download VBB…"
+msgstr "Scarica VBB..."
+
 msgid "Download data from Overpass API, filtered by relevance for MATSim."
 msgstr ""
 "Scarica dati da Overpass API, prendendo solo quelli rilevanti a MATSim."
 
 msgid "Download from Overpass API..."
 msgstr "Scarica da Overpass API..."
+
+msgid "Download members and stop areas"
+msgstr "Scarica membri ed aree di stop"
+
+msgid "Duplicated Id {0} not allowed."
+msgstr "Id Duplicato {0} non permesso."
+
+msgid "Export MATSim network to shape file..."
+msgstr "Esporta la rete MATSim su file shape..."
+
+msgid "Export MATSim network to shape file…"
+msgstr "Esporta la rete su file shape..."
+
+msgid "Export MATSim transit schedule…"
+msgstr "Esporta orari di transito MATSim..."
+
+msgid ""
+"Export failed due to validation errors. See validation layer for details."
+msgstr ""
+"Impossibile esportare perché sono stati riscontrati degli errori. Vedi il "
+"livello della validazione per ulteriori dettagli."
+
+msgid "Exported network xml version"
+msgstr "Rete esportata in versione XML"
+
+msgid "Failure"
+msgstr "Guasto"
 
 msgid "Fix transit schedule validation errors"
 msgstr "Correggi gli errori di validazioni degli orari di transito"
@@ -66,17 +114,31 @@ msgstr "Importa"
 msgid "Import MATSim scenario"
 msgstr "Importa lo scenario di MATSim"
 
+msgid "Include road type in output"
+msgstr "Includi il tipo di strada nel risultato"
+
+msgid ""
+"Incomplete route {0} - Auto repair to download missing elements (cannot be "
+"undone)"
+msgstr ""
+"Itinerario {0} incompleto - ripara automaticamente per scaricare gli "
+"elementi mancanti (non si può tornare indietro)"
+
 msgid "Information"
 msgstr "Informazioni"
 
-#, java-format
+msgid "Keep Paths"
+msgstr "Mantieni Percorsi"
+
 msgid "Lines: {0} / Routes: {1}"
 msgstr "Linee: {0} / Itinerari: {1}"
+
+msgid "Link offset for overlapping links"
+msgstr "Scostamento per i collegamenti che si incrociano"
 
 msgid "Links/Nodes"
 msgstr "Collegamenti/Nodi"
 
-#, java-format
 msgid "Links: {0} / Nodes: {1}"
 msgstr "Collegamenti: {0} / Nodi: {1}"
 
@@ -89,10 +151,12 @@ msgstr "MATSim"
 msgid "MATSim Import"
 msgstr "Importa da MATSim"
 
+msgid "MATSim Transit Schedule Files"
+msgstr "File degli orari di transito MATSim"
+
 msgid "MATSimValidation"
 msgstr "ValidazioneMATSim"
 
-#, java-format
 msgid "Menu: {0}"
 msgstr "Menu: {0}"
 
@@ -111,17 +175,68 @@ msgstr "Niente da esportare. Prima è necessario ottenere dei dati."
 msgid "OSM Repair"
 msgstr "Ripara OSM"
 
+msgid "Only convert hierarchies up to: "
+msgstr "Converti solamente le gerarchie fino a:"
+
+msgid "Route {0} with no Route Master"
+msgstr "Itinerario {0} senza itinerario master"
+
 msgid "Save MATSim network file"
 msgstr "Salva il file della rete di MATSim"
 
+msgid "Select to download {0} highways in the selected download area."
+msgstr ""
+"Seleziona per scaricare {0} strade nell’area di scaricamento selezionata."
+
+msgid "Select to download {0} routes in the selected download area."
+msgstr ""
+"Seleziona per scaricare {0} itinerari nell’area di scaricamento selezionata."
+
+msgid "Set conversion defaults"
+msgstr "Impostazioni predefinite della conversione"
+
+msgid "Shape Files"
+msgstr "File di Figura"
+
+msgid "Show internal Ids in table"
+msgstr "Mostra gli identificatori interni nella tabella"
+
+msgid "Show link-Ids"
+msgstr "Mostra i link-Ids"
+
 msgid "Simulate"
 msgstr "Simula"
+
+msgid "Test for incomplete routes"
+msgstr "Verifica le rotte incomplete"
+
+msgid "Test for master routes"
+msgstr "Verifica degli itinerari master"
+
+msgid "Transit routes lite"
+msgstr "Itinerari di transito semplificati"
+
+msgid "Transit support [alpha]"
+msgstr "Supporto al trasporto pubblico [alfa]"
+
+msgid "Update tags for public transport stops"
+msgstr "Aggiornare i tags per le fermate del trasporto pubblico"
+
+msgid "Validate TransitSchedule"
+msgstr "Valida TransitSchedule"
 
 msgid "Validates MATSim-related network data"
 msgstr "Convalida i dati della rete relativi a MATSim"
 
 msgid "Validates MATSim-related transit schedule data"
 msgstr "Convalida i dati degli orari di transito relativi a MATSim"
+
+msgid ""
+"Validaton resulted in warnings.\n"
+" Proceed?"
+msgstr ""
+"Il controllo ha riportato degli avvertimenti.\n"
+" Continuare?"
 
 msgid "Visualization"
 msgstr "Visualizzazione"
@@ -132,7 +247,6 @@ msgstr "Attenzione"
 msgid "edit network attributes"
 msgstr "modifica gli attributi della rete"
 
-#. Plugin description for josm-matsim-plugin
 msgid ""
 "Allows to edit and extract network information for the traffic simulation "
 "MATSim"

--- a/src/main/po/pl.po
+++ b/src/main/po/pl.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'matsim' (pl)
-# Copyright (C) 2018 
+# Copyright (C) 2019
 # This file is distributed under the same license as the josm-plugin_matsim package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_matsim v0.9.3-1-g5f14357\n"
+"Project-Id-Version: josm-plugin_matsim 0.8.7-55-g88e42cd\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-26 15:50+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2019-08-26 09:01+0000\n"
+"PO-Revision-Date: 2018-05-23 08:43+0000\n"
 "Language-Team: Polish (https://www.transifex.com/josm/teams/2544/pl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,7 +17,6 @@ msgstr ""
 "Language: pl\n"
 "Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
 
-#. Visualization
 msgid "Activate MATSim Renderer"
 msgstr "Aktywuj renderer MATSim"
 
@@ -79,9 +78,6 @@ msgstr "Pobieranie z API Overpass..."
 msgid "Download members and stop areas"
 msgstr "Pobierz członków i obszary przystanków"
 
-#. create error with message
-#. create warning with message
-#, java-format
 msgid "Duplicated Id {0} not allowed."
 msgstr "Nie jest dopuszczone duplikowanie Id {0}."
 
@@ -100,7 +96,6 @@ msgstr ""
 "Eksport nieudany ze względu na błędy weryfikacji. Zobacz warstwę "
 "weryfikacji, aby uzyskać więcej szczegółów."
 
-#. General
 msgid "Exported network xml version"
 msgstr "Sieć wyeksportowana do wersji xml"
 
@@ -122,7 +117,6 @@ msgstr "Importuj scenariusz MATSim"
 msgid "Include road type in output"
 msgstr "Dołącz rodzaje dróg do wyjścia"
 
-#, java-format
 msgid ""
 "Incomplete route {0} - Auto repair to download missing elements (cannot be "
 "undone)"
@@ -136,7 +130,6 @@ msgstr "Informacje"
 msgid "Keep Paths"
 msgstr "Zachowaj ścieżki"
 
-#, java-format
 msgid "Lines: {0} / Routes: {1}"
 msgstr "Linie: {0} / Trasy: {1}"
 
@@ -146,7 +139,6 @@ msgstr "Przesunięcie dla nakładających się linków"
 msgid "Links/Nodes"
 msgstr "Linki/Węzły"
 
-#, java-format
 msgid "Links: {0} / Nodes: {1}"
 msgstr "Linki: {0} / Węzły: {1}"
 
@@ -165,7 +157,6 @@ msgstr "MATSim Transit Schedule Files"
 msgid "MATSimValidation"
 msgstr "MATSimValidation"
 
-#, java-format
 msgid "Menu: {0}"
 msgstr "Menu: {0}"
 
@@ -187,18 +178,15 @@ msgstr "Naprawa OSM"
 msgid "Only convert hierarchies up to: "
 msgstr "Przekształcaj tylko hierarchie do: "
 
-#, java-format
 msgid "Route {0} with no Route Master"
 msgstr "Trasa {0} nie zawiera głównej trasy"
 
 msgid "Save MATSim network file"
 msgstr "Zapisz plik sieci MATSim"
 
-#, java-format
 msgid "Select to download {0} highways in the selected download area."
 msgstr "Wybierz, aby pobrać {0} dróg w zaznaczonym obszarze."
 
-#, java-format
 msgid "Select to download {0} routes in the selected download area."
 msgstr "Wybierz, aby pobrać {0} tras w zaznaczonym obszarze."
 
@@ -222,6 +210,12 @@ msgstr "Testuj niekompletne trasy"
 
 msgid "Test for master routes"
 msgstr "Sprawdź główne trasy"
+
+msgid "Transit routes lite"
+msgstr "Trasy przejazdów lite"
+
+msgid "Transit support [alpha]"
+msgstr "Wsparcie transportu [alfa]"
 
 msgid "Update tags for public transport stops"
 msgstr "Aktualizacja znaczników dla przystanków transportu publicznego"
@@ -251,7 +245,6 @@ msgstr "Ostrzeżenie"
 msgid "edit network attributes"
 msgstr "edytuj właściwości sieci"
 
-#. Plugin description for josm-matsim-plugin
 msgid ""
 "Allows to edit and extract network information for the traffic simulation "
 "MATSim"

--- a/src/main/po/pt.po
+++ b/src/main/po/pt.po
@@ -1,0 +1,148 @@
+# Translations for the JOSM plugin 'matsim' (pt)
+# Copyright (C) 2019
+# This file is distributed under the same license as the josm-plugin_matsim package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: josm-plugin_matsim 0.8.7-55-g88e42cd\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-08-26 09:01+0000\n"
+"PO-Revision-Date: 2018-05-23 08:43+0000\n"
+"Language-Team: Portuguese (https://www.transifex.com/josm/teams/2544/pt/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: pt\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Activate MATSim Renderer"
+msgstr "Ativar renderizador MATSim"
+
+msgid "Activate hierarchy filter"
+msgstr "Ativar filtro de hierarquia"
+
+msgid "Check for Incomplete Routes"
+msgstr "Verificar rotas incompletas"
+
+msgid "Clean Network"
+msgstr "Limpar Rede"
+
+msgid "Click to download the currently selected area"
+msgstr "Clique para descarregar a área selecionada"
+
+msgid "Configure the MATSim plugin."
+msgstr "Configurar o módulo MATSim."
+
+msgid "Contacting OSM Server..."
+msgstr "A contactar o servidor OpenStreetMap..."
+
+msgid "Convert Osm layer to MATSim network layer"
+msgstr "Converter camada Osm numa camada de rede MATSim"
+
+msgid "Convert to MATSim Layer"
+msgstr "Converter numa camada MATSim"
+
+msgid "Convert to MATSim Network"
+msgstr "Converter numa rede MATSim"
+
+msgid "Converter"
+msgstr "Conversor"
+
+msgid "Create Master Routes"
+msgstr "Criar Rotas Mestre"
+
+msgid "Create areas for public transport stops"
+msgstr "Criar áreas para paragens de transportes públicos"
+
+msgid "Create new Network"
+msgstr "Criar nova Rede"
+
+msgid "Defaults"
+msgstr "Padrões"
+
+msgid "Download"
+msgstr "Descarregar"
+
+msgid "Download VBB…"
+msgstr "Descarregar VBB…"
+
+msgid "Download from Overpass API..."
+msgstr "Descarregar da API do Overpass…"
+
+msgid "Download members and stop areas"
+msgstr "Descarregar membros e áreas de paragens"
+
+msgid "Duplicated Id {0} not allowed."
+msgstr "ID duplicado {0} não permitido."
+
+msgid "Export MATSim network to shape file..."
+msgstr "Exportar rede MATSim para um ficheiro shape..."
+
+msgid "Export MATSim network to shape file…"
+msgstr "Exportar rede MATSim para um ficheiro shape…"
+
+msgid "Failure"
+msgstr "Falha"
+
+msgid "General"
+msgstr "Geral"
+
+msgid "Import"
+msgstr "Importar"
+
+msgid "Import MATSim scenario"
+msgstr "Importar cenário MATSim"
+
+msgid "Include road type in output"
+msgstr "Incluir tipo de estrada na saída"
+
+msgid "Information"
+msgstr "Informação"
+
+msgid "Lines: {0} / Routes: {1}"
+msgstr "Linhas: {0} / Rotas: {1}"
+
+msgid "MASim preferences"
+msgstr "Preferências MASim"
+
+msgid "MATSim"
+msgstr "MATSim"
+
+msgid "MATSim Import"
+msgstr "Importação MATSim"
+
+msgid "Menu: {0}"
+msgstr "Menu: {0}"
+
+msgid "Network Attributes"
+msgstr "Atributos da Rede"
+
+msgid "New MATSim network"
+msgstr "Nova rede MATSim"
+
+msgid "No MATSim layer active"
+msgstr "Nenhum camada MATSim ativa"
+
+msgid "Nothing to export. Get some data first."
+msgstr "Nada a exportar. Obtenha primeiro alguns dados."
+
+msgid "Simulate"
+msgstr "Simular"
+
+msgid ""
+"Validaton resulted in warnings.\n"
+" Proceed?"
+msgstr ""
+"A validação resultou em avisos.\n"
+" Continuar?"
+
+msgid "Visualization"
+msgstr "Visualização"
+
+msgid "Warning"
+msgstr "Aviso"
+
+msgid "edit network attributes"
+msgstr "editar atributos da rede"

--- a/src/main/po/ru.po
+++ b/src/main/po/ru.po
@@ -1,15 +1,15 @@
 # Translations for the JOSM plugin 'matsim' (ru)
-# Copyright (C) 2018 
+# Copyright (C) 2019
 # This file is distributed under the same license as the josm-plugin_matsim package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
-#, fuzzy
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_matsim v0.9.3-1-g5f14357\n"
+"Project-Id-Version: josm-plugin_matsim 0.8.7-55-g88e42cd\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-26 15:50+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2019-08-26 09:01+0000\n"
+"PO-Revision-Date: 2018-05-23 08:43+0000\n"
 "Language-Team: Russian (https://www.transifex.com/josm/teams/2544/ru/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,7 +17,6 @@ msgstr ""
 "Language: ru\n"
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#. Visualization
 msgid "Activate MATSim Renderer"
 msgstr "Активировать отрисовщик MATSim"
 
@@ -51,8 +50,20 @@ msgstr "Преобразовать в сеть MATSim"
 msgid "Converter"
 msgstr "Конвертер"
 
+msgid "Create Master Routes"
+msgstr "Создать мастер-маршрут"
+
+msgid "Create areas for public transport stops"
+msgstr "Создать области для остановок общественного транспорта"
+
 msgid "Create new Network"
 msgstr "Создать новую сеть"
+
+msgid "Defaults"
+msgstr "По умалчанию"
+
+msgid "Download"
+msgstr "Скачать"
 
 msgid "Download data from Overpass API, filtered by relevance for MATSim."
 msgstr ""
@@ -64,11 +75,14 @@ msgstr "Скачать с Overpass API..."
 msgid "Download members and stop areas"
 msgstr "Скачать участников и остановочные зоны"
 
-#. create error with message
-#. create warning with message
-#, java-format
 msgid "Duplicated Id {0} not allowed."
 msgstr "Дублирование Id {0} запрещено."
+
+msgid "Export MATSim network to shape file..."
+msgstr "Экспортировать сеть MATSim в shape-файл..."
+
+msgid "Export MATSim network to shape file…"
+msgstr "Экспортировать сеть MATSim в shape-файл…"
 
 msgid ""
 "Export failed due to validation errors. See validation layer for details."
@@ -88,7 +102,6 @@ msgstr "Импортировать сценарий MATSim"
 msgid "Information"
 msgstr "Информация"
 
-#, java-format
 msgid "Lines: {0} / Routes: {1}"
 msgstr "Линий: {0} / маршрутов: {1}"
 
@@ -101,7 +114,6 @@ msgstr "MATSim"
 msgid "MATSim Import"
 msgstr "Импорт MATSim"
 
-#, java-format
 msgid "Menu: {0}"
 msgstr "Меню: {0}"
 
@@ -117,6 +129,9 @@ msgstr "Нет активного слоя MATSim"
 msgid "Nothing to export. Get some data first."
 msgstr "Нечего экспортировать. Сначала получите какие-нибудь данные."
 
+msgid "Route {0} with no Route Master"
+msgstr "Маршрут {0} без мастер-маршрута"
+
 msgid "Save MATSim network file"
 msgstr "Сохранить файл сети MATSim"
 
@@ -128,6 +143,9 @@ msgstr "Симуляция"
 
 msgid "Test for incomplete routes"
 msgstr "Проверка на неполные маршруты"
+
+msgid "Test for master routes"
+msgstr "Проверка мастер-маршрутов"
 
 msgid "Update tags for public transport stops"
 msgstr "Обновить теги для остановок общественного транспорта"
@@ -141,7 +159,6 @@ msgstr "Предупреждение"
 msgid "edit network attributes"
 msgstr "изменить атрибуты сети"
 
-#. Plugin description for josm-matsim-plugin
 msgid ""
 "Allows to edit and extract network information for the traffic simulation "
 "MATSim"

--- a/src/main/po/zh_TW.po
+++ b/src/main/po/zh_TW.po
@@ -1,0 +1,246 @@
+# Translations for the JOSM plugin 'matsim' (zh_TW)
+# Copyright (C) 2019
+# This file is distributed under the same license as the josm-plugin_matsim package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: josm-plugin_matsim 0.8.7-55-g88e42cd\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-08-26 09:01+0000\n"
+"PO-Revision-Date: 2018-05-23 08:43+0000\n"
+"Language-Team: Chinese (Taiwan) (https://www.transifex.com/josm/teams/2544/zh_TW/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: zh_TW\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgid "Activate MATSim Renderer"
+msgstr "啟用的 MATSim 渲染"
+
+msgid "Activate hierarchy filter"
+msgstr "啟用的階層篩器"
+
+msgid "Check for Incomplete Routes"
+msgstr "檢查不完整的路線"
+
+msgid "Clean Network"
+msgstr "清理網路"
+
+msgid "Click to download the currently selected area"
+msgstr "點選以下載目前選取的區域"
+
+msgid "Configure the MATSim plugin."
+msgstr "設定 MATSim 插件。"
+
+msgid "Contacting OSM Server..."
+msgstr "正在連接 OSM 伺服器..."
+
+msgid "Convert Osm layer to MATSim network layer"
+msgstr "轉換 Osm 圖層成為 MATSim 網路圖層"
+
+msgid "Convert to MATSim Layer"
+msgstr "轉換成 MATSim 圖層"
+
+msgid "Convert to MATSim Network"
+msgstr "轉換成 MATSim 網路"
+
+msgid "Converter"
+msgstr "轉換器"
+
+msgid "Create Master Routes"
+msgstr "新建主要路線"
+
+msgid "Create areas for public transport stops"
+msgstr "新建大眾運輸站點的區域"
+
+msgid "Create new Network"
+msgstr "新建新網路"
+
+msgid "Defaults"
+msgstr "預設值"
+
+msgid "Download"
+msgstr "下載"
+
+msgid "Download VBB…"
+msgstr "下載 VBB..."
+
+msgid "Download data from Overpass API, filtered by relevance for MATSim."
+msgstr "從 Overpass API 下載資料，並且為了 MATSim 用相關性篩選。"
+
+msgid "Download from Overpass API..."
+msgstr "從 Overpass API 下載..."
+
+msgid "Download members and stop areas"
+msgstr "下載成員和站點區域"
+
+msgid "Duplicated Id {0} not allowed."
+msgstr "不允許重覆的 Id {0}。"
+
+msgid "Export MATSim network to shape file..."
+msgstr "匯出 MATSim 網路到 shape 檔案..."
+
+msgid "Export MATSim network to shape file…"
+msgstr "匯出 MATSim 網路到 shape 檔案..."
+
+msgid "Export MATSim transit schedule…"
+msgstr "匯出 MATSim 交通時刻表..."
+
+msgid ""
+"Export failed due to validation errors. See validation layer for details."
+msgstr "因為驗證錯誤匯入失敗，請見驗證圖層得知詳情。"
+
+msgid "Exported network xml version"
+msgstr "匯出的網路 xml 版本"
+
+msgid "Failure"
+msgstr "失敗"
+
+msgid "Fix transit schedule validation errors"
+msgstr "修復交通時刻表驗證錯誤"
+
+msgid "General"
+msgstr "一般"
+
+msgid "Import"
+msgstr "匯入"
+
+msgid "Import MATSim scenario"
+msgstr "匯入 MATSim 場景"
+
+msgid "Include road type in output"
+msgstr "輸出包括道路類型"
+
+msgid ""
+"Incomplete route {0} - Auto repair to download missing elements (cannot be "
+"undone)"
+msgstr "不完整的路線 {0} - 自動修復下載遺失的元素 (無法復原)"
+
+msgid "Information"
+msgstr "資訊"
+
+msgid "Keep Paths"
+msgstr "保留路徑"
+
+msgid "Lines: {0} / Routes: {1}"
+msgstr "線段：{0} / 路線： {1}"
+
+msgid "Link offset for overlapping links"
+msgstr "連結偏移為了重覆連結"
+
+msgid "Links/Nodes"
+msgstr "連結/節點"
+
+msgid "Links: {0} / Nodes: {1}"
+msgstr "連結：{0} / 節點：{1}"
+
+msgid "MASim preferences"
+msgstr "MASim 偏好設定"
+
+msgid "MATSim"
+msgstr "MATSim"
+
+msgid "MATSim Import"
+msgstr "MATSim 匯入"
+
+msgid "MATSim Transit Schedule Files"
+msgstr "MATSim 交通時刻表檔案"
+
+msgid "MATSimValidation"
+msgstr "MATSimValidation"
+
+msgid "Menu: {0}"
+msgstr "選單：{0}"
+
+msgid "Network Attributes"
+msgstr "網路屬性"
+
+msgid "New MATSim network"
+msgstr "新 MATSim 網路"
+
+msgid "No MATSim layer active"
+msgstr "沒有 MATSim 圖層啟用"
+
+msgid "Nothing to export. Get some data first."
+msgstr "沒有東西可匯出。請先取得一些資料。"
+
+msgid "OSM Repair"
+msgstr "OSM 維修"
+
+msgid "Only convert hierarchies up to: "
+msgstr "僅將層次結構轉換為："
+
+msgid "Route {0} with no Route Master"
+msgstr "路線 {0} 沒有主要路線"
+
+msgid "Save MATSim network file"
+msgstr "儲存 MATSim 網路檔案"
+
+msgid "Select to download {0} highways in the selected download area."
+msgstr "在選取的下載區域中，選擇下載公路 {0} 。"
+
+msgid "Select to download {0} routes in the selected download area."
+msgstr "在選取的下載區域選擇下載路線 {0}。"
+
+msgid "Set conversion defaults"
+msgstr "設定轉換預設置"
+
+msgid "Shape Files"
+msgstr "Shape 檔案"
+
+msgid "Show internal Ids in table"
+msgstr "在表單中顯示內部 Ids"
+
+msgid "Show link-Ids"
+msgstr "顯示 link-Ids"
+
+msgid "Simulate"
+msgstr "模擬"
+
+msgid "Test for incomplete routes"
+msgstr "測試不完整的路線"
+
+msgid "Test for master routes"
+msgstr "測試主要路線"
+
+msgid "Transit routes lite"
+msgstr "交通路線 lite"
+
+msgid "Transit support [alpha]"
+msgstr "交通支援 [alpha]"
+
+msgid "Update tags for public transport stops"
+msgstr "為大眾運輸站點更新標籤"
+
+msgid "Validate TransitSchedule"
+msgstr "驗證 TransitSchedule"
+
+msgid "Validates MATSim-related network data"
+msgstr "驗證 MATSim 相關網路資料"
+
+msgid "Validates MATSim-related transit schedule data"
+msgstr "驗證 MATSim 相關交通時刻表資料"
+
+msgid ""
+"Validaton resulted in warnings.\n"
+" Proceed?"
+msgstr ""
+"警告中的驗證結果。\n"
+" 繼續嗎？"
+
+msgid "Visualization"
+msgstr "驗證程序"
+
+msgid "Warning"
+msgstr "警告"
+
+msgid "edit network attributes"
+msgstr "編輯網路屬性"
+
+msgid ""
+"Allows to edit and extract network information for the traffic simulation "
+"MATSim"
+msgstr "為了交通模擬 MATSim，允許編輯和截取網路資訊"


### PR DESCRIPTION
I noticed that you use an old version of [GTFS-lib](https://github.com/conveyal/gtfs-lib/releases).

<del>This PR updates the dependency from `v1.1.0` to `v3.3.0`. But note that it does not deal with compilation issues that this causes, because the API of that library changed.</del>

<del>I'm not really familiar with this library or GTFS processing in general, so it's probably better if I leave the task of adapting the plugin to that newer version up to you :wink:.</del>