### PR TITLE
Change MapRenderer to be compatible with JOSM >= 13810

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.openstreetmap.josm' version '0.3.4'
+    id 'org.openstreetmap.josm' version '0.4.4'
     id 'java'
     id 'eclipse'
     id 'idea'
@@ -44,15 +44,16 @@ gitVersion.waitFor()
 version = gitVersion.in.text.trim()
 archivesBaseName = "matsim"
 josm {
-    josmCompileVersion = 13332
+    josmCompileVersion = 13814
     manifest {
         author = "Nico Kuehnel"
         description = "Allows to edit and extract network information for the traffic simulation MATSim"
         iconPath = "images/dialogs/matsim-scenario.png"
-        minJosmVersion = 12881
+        minJosmVersion = 13810
         mainClass = "org.matsim.contrib.josm.MATSimPlugin"
         pluginDependencies << 'jts' << 'apache-commons' << 'apache-http'
         website = new URL("http://www.matsim.org")
+        oldVersionDownloadLink 12881, 'v0.8.8', new URL('https://github.com/matsim-org/josm-matsim-plugin/releases/download/v0.8.8/matsim.jar')
         oldVersionDownloadLink 12450, 'v0.7.9', new URL('https://github.com/matsim-org/josm-matsim-plugin/releases/download/v0.7.9/matsim.jar')
         oldVersionDownloadLink 10340, 'v0.7.5', new URL('https://github.com/matsim-org/josm-matsim-plugin/releases/download/v0.7.5/matsim.jar')
         oldVersionDownloadLink  9278, 'v0.5.9', new URL('https://github.com/matsim-org/josm-matsim-plugin/releases/download/v0.5.9/matsim.jar')

--- a/src/main/java/org/matsim/contrib/josm/MapRenderer.java
+++ b/src/main/java/org/matsim/contrib/josm/MapRenderer.java
@@ -6,6 +6,8 @@ import org.matsim.contrib.josm.model.MLink;
 import org.matsim.contrib.josm.model.OsmConvertDefaults;
 import org.openstreetmap.josm.data.Bounds;
 import org.openstreetmap.josm.data.osm.DataSet;
+import org.openstreetmap.josm.data.osm.IPrimitive;
+import org.openstreetmap.josm.data.osm.OsmData;
 import org.openstreetmap.josm.data.osm.OsmPrimitive;
 import org.openstreetmap.josm.data.osm.Way;
 import org.openstreetmap.josm.data.osm.visitor.paint.MapRendererFactory;
@@ -69,7 +71,7 @@ public class MapRenderer extends StyledMapRenderer {
 
 
     @Override
-    public void render(DataSet data, boolean renderVirtualNodes, Bounds bounds) {
+    public void render(OsmData<?, ?, ?, ?> data, boolean renderVirtualNodes, Bounds bounds) {
         super.render(data, renderVirtualNodes, bounds);
         if(MainApplication.getLayerManager().getEditLayer() instanceof MATSimLayer) {
             this.g.drawImage(image, (int) (this.mapState.getViewWidth() - 160), 10, null);
@@ -173,7 +175,7 @@ public class MapRenderer extends StyledMapRenderer {
          * represented.
          */
         @Override
-        public String compose(OsmPrimitive prim) {
+        public String compose(IPrimitive prim) {
             StringBuilder sB = new StringBuilder();
             if (way2Links.containsKey(prim)) {
                 for (MLink link : way2Links.get(prim)) {


### PR DESCRIPTION
Fixes #81 

Not related to this PR: Please remember to change the name of the environment variable `$TRANSIFEX_TOKEN` to `TRANSIFEX_TOKEN` at https://travis-ci.org/matsim-org/josm-matsim-plugin/settings, so we can translate the plugin on Transifex. The value has to be an API token from https://www.transifex.com/user/settings/api/