### PR TITLE
Update dependencies, add new translations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.openstreetmap.josm' version '0.4.4'
+    id 'org.openstreetmap.josm' version '0.4.8'
     id 'java'
     id 'eclipse'
     id 'idea'
@@ -37,17 +37,17 @@ dependencies {
     packIntoJar ('org.matsim.contrib:otfvis:0.10.0-SNAPSHOT') {changing = true}
     packIntoJar ('com.github.conveyal:gtfs-lib:v1.1.0')
 
-    testImplementation group: 'junit', name: 'junit', version: '4.12'
+    def junitVersion = "5.2.0"
+    testImplementation ("org.junit.jupiter:junit-jupiter-api:$junitVersion")
+    testRuntimeOnly ("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    testImplementation ("org.junit.vintage:junit-vintage-engine:$junitVersion")
     testImplementation ('org.openstreetmap.josm:josm-unittest:') {changing = true}
 }
 
 sourceCompatibility = 1.8
-def gitVersion = ['git', 'describe', '--always', '--tags', '--dirty'].execute()
-gitVersion.waitFor()
-version = gitVersion.in.text.trim()
 archivesBaseName = "matsim"
 josm {
-    josmCompileVersion = 13814
+    josmCompileVersion = 13878
     manifest {
         author = "Nico Kuehnel"
         description = "Allows to edit and extract network information for the traffic simulation MATSim"
@@ -64,14 +64,6 @@ josm {
     i18n {
       pathTransformer = getGithubPathTransformer("matsim-org/josm-matsim-plugin")
     }
-}
-
-jar {
-    // Exclude these entries of dependencies from the produced *.jar file
-    exclude 'META-INF/DEPENDENCIES'
-    exclude 'META-INF/LICENSE*'
-    exclude 'META-INF/NOTICE*'
-    exclude 'META-INF/maven'
 }
 
 tasks.test.outputs.dir("$buildDir/test-output")

--- a/src/main/po/de.po
+++ b/src/main/po/de.po
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_matsim v0.9.0\n"
+"Project-Id-Version: josm-plugin_matsim v0.9.0-4-ge4ee56c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-23 10:15+0000\n"
+"POT-Creation-Date: 2018-05-25 11:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: German (https://www.transifex.com/josm/teams/2544/de/)\n"
 "MIME-Version: 1.0\n"
@@ -16,6 +16,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. Visualization
+msgid "Activate MATSim Renderer"
+msgstr "MATSim-Renderer aktivieren"
+
+msgid "Activate hierarchy filter"
+msgstr "Hierarchiefilter aktivieren"
+
+msgid "Check for Incomplete Routes"
+msgstr "Auf unvollständige Routen überprüfen"
+
+msgid "Clean Network"
+msgstr "Netzwerk bereinigen"
 
 msgid "Click to download the currently selected area"
 msgstr "Klicken Sie, um die derzeitig ausgewählten Bereiche herunterzuladen"
@@ -41,19 +54,13 @@ msgstr "Konverter"
 msgid "Create new Network"
 msgstr "Neues Netzwerk erzeugen"
 
-msgid "CreateStopAreas"
-msgstr "ErzeugeHaltestellenBereiche"
-
 msgid "Defaults"
 msgstr "Standardwerte"
 
 msgid "Download"
 msgstr "Daten herunterladen"
 
-msgid "Download VBB."
-msgstr "VBB herunterladen."
-
-msgid "Download VBB..."
+msgid "Download VBB…"
 msgstr "VBB herunterladen…"
 
 msgid "Download data from Overpass API, filtered by relevance for MATSim."
@@ -63,14 +70,21 @@ msgstr ""
 msgid "Download from Overpass API..."
 msgstr "Von der Overpass API herunterladen…"
 
-msgid "Export MATSim transit schedule..."
+msgid "Download members and stop areas"
+msgstr "Lade Mitglieder und Haltestellenbereiche herunter"
+
+#. create error with message
+#. create warning with message
+#, java-format
+msgid "Duplicated Id {0} not allowed."
+msgstr "Doppelte ID {0} ist nicht erlaubt."
+
+msgid "Export MATSim transit schedule…"
 msgstr "Den MATSim Transit-Ablaufplan exportieren…"
 
-msgid "Export the transit schedule."
-msgstr "Den Transit-Ablaufplan exportieren."
-
-msgid "Export transit schedule"
-msgstr "Transit-Ablaufplan exportieren"
+#. General
+msgid "Exported network xml version"
+msgstr "Version des exportierten XML-Netzwerks"
 
 msgid "Fix transit schedule validation errors"
 msgstr "Fehler in den Prüfergebnissen für Transit-Ablaufpläne beheben"
@@ -84,11 +98,8 @@ msgstr "Importieren"
 msgid "Import MATSim scenario"
 msgstr "MATSim-Szenario importieren"
 
-msgid "IncompleteRoutesTest"
-msgstr "UnvollständigeRoutenTest"
-
-msgid "IncompleterRoutesTest"
-msgstr "UnvollständigeRoutenTest"
+msgid "Include road type in output"
+msgstr "Straßentyp soll in der Ausgabe enthalten sein"
 
 msgid "Information"
 msgstr "Information"
@@ -116,18 +127,12 @@ msgstr "MATSim-Import"
 msgid "MATSimValidation"
 msgstr "MATSimValidierung"
 
-msgid "MasterRoutesTest"
-msgstr "MasterRoutenTest"
-
 #, java-format
 msgid "Menu: {0}"
 msgstr "Menü: {0}"
 
 msgid "Network Attributes"
 msgstr "Netzwerk-Attribute"
-
-msgid "New MATSim Network"
-msgstr "Neues MATSim-Netzwerk"
 
 msgid "New MATSim network"
 msgstr "Neues MATSim-Netzwerk"
@@ -139,19 +144,35 @@ msgid "Nothing to export. Get some data first."
 msgstr "Nichts zu exportieren. Es sind keine Daten vorhanden."
 
 msgid "OSM Repair"
-msgstr "OSM Reparatur"
+msgstr "OSM-Reparatur"
+
+msgid "Only convert hierarchies up to: "
+msgstr "Hierarchien nur konvertieren bis höchstens:"
 
 msgid "Save MATSim network file"
 msgstr "MATSim Netzwerk-Datei speichern"
 
-msgid "Select to download "
-msgstr "Zum Herunterladen auswählen"
+#, java-format
+msgid "Select to download {0} highways in the selected download area."
+msgstr ""
+"Auswählen, um {0} Straßen im ausgewählten Herunterladebereich "
+"herunterzuladen."
+
+#, java-format
+msgid "Select to download {0} routes in the selected download area."
+msgstr ""
+"Auswählen, um {0} Routen im ausgewählten Herunterladebereich "
+"herunterzuladen."
+
+msgid "Show internal Ids in table"
+msgstr "Interne IDs in Tabelle anzeigen"
 
 msgid "Simulate"
 msgstr "Simulieren"
 
-msgid "UpdateStopTags"
-msgstr "AktualisiereStopTags"
+#. Converter
+msgid "Transit support [alpha]"
+msgstr "Transit-Unterstützung [alpha]"
 
 msgid "Validates MATSim-related network data"
 msgstr "Validiert Netzwerkdaten, die mit MATSim zusammenhängen"
@@ -160,8 +181,18 @@ msgid "Validates MATSim-related transit schedule data"
 msgstr ""
 "Überprüft Daten für Transit-Ablaufpläne, die mit MATSim zusammenhängen"
 
+msgid ""
+"Validaton resulted in warnings.\n"
+" Proceed?"
+msgstr ""
+"Prüfergebnis enthält Warnungen.\n"
+"Weitermachen?"
+
 msgid "Visualization"
 msgstr "Visualisierung"
+
+msgid "Warning"
+msgstr "Warnung"
 
 msgid "edit network attributes"
 msgstr "Netzwerk-Attribute bearbeiten"

--- a/src/main/po/it.po
+++ b/src/main/po/it.po
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_matsim v0.9.0\n"
+"Project-Id-Version: josm-plugin_matsim v0.9.0-4-ge4ee56c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-23 10:15+0000\n"
+"POT-Creation-Date: 2018-05-25 11:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: Italian (https://www.transifex.com/josm/teams/2544/it/)\n"
 "MIME-Version: 1.0\n"
@@ -41,20 +41,11 @@ msgstr "Convertitore"
 msgid "Create new Network"
 msgstr "Crea una nuova rete"
 
-msgid "CreateStopAreas"
-msgstr "CreaAreeStop"
-
 msgid "Defaults"
 msgstr "Predefiniti"
 
 msgid "Download"
 msgstr "Scarica"
-
-msgid "Download VBB."
-msgstr "Scarica VBB."
-
-msgid "Download VBB..."
-msgstr "Scarica VBB..."
 
 msgid "Download data from Overpass API, filtered by relevance for MATSim."
 msgstr ""
@@ -62,15 +53,6 @@ msgstr ""
 
 msgid "Download from Overpass API..."
 msgstr "Scarica da Overpass API..."
-
-msgid "Export MATSim transit schedule..."
-msgstr "Esporta gli orari di transito di MATSim..."
-
-msgid "Export the transit schedule."
-msgstr "Esporta gli orari di transito."
-
-msgid "Export transit schedule"
-msgstr "Esporta gli orari di transito"
 
 msgid "Fix transit schedule validation errors"
 msgstr "Correggi gli errori di validazioni degli orari di transito"
@@ -83,12 +65,6 @@ msgstr "Importa"
 
 msgid "Import MATSim scenario"
 msgstr "Importa lo scenario di MATSim"
-
-msgid "IncompleteRoutesTest"
-msgstr "TestItinerariIncompleti"
-
-msgid "IncompleterRoutesTest"
-msgstr "TestItinerariIncompleti"
 
 msgid "Information"
 msgstr "Informazioni"
@@ -116,18 +92,12 @@ msgstr "Importa da MATSim"
 msgid "MATSimValidation"
 msgstr "ValidazioneMATSim"
 
-msgid "MasterRoutesTest"
-msgstr "TestItinerarioPrincipale"
-
 #, java-format
 msgid "Menu: {0}"
 msgstr "Menu: {0}"
 
 msgid "Network Attributes"
 msgstr "Attributi della rete"
-
-msgid "New MATSim Network"
-msgstr "Nuova rete di MATSim"
 
 msgid "New MATSim network"
 msgstr "Nuova rete di MATSim"
@@ -144,14 +114,8 @@ msgstr "Ripara OSM"
 msgid "Save MATSim network file"
 msgstr "Salva il file della rete di MATSim"
 
-msgid "Select to download "
-msgstr "Seleziona per scaricare"
-
 msgid "Simulate"
 msgstr "Simula"
-
-msgid "UpdateStopTags"
-msgstr "AggiornaEtichetteStop"
 
 msgid "Validates MATSim-related network data"
 msgstr "Convalida i dati della rete relativi a MATSim"
@@ -161,6 +125,9 @@ msgstr "Convalida i dati degli orari di transito relativi a MATSim"
 
 msgid "Visualization"
 msgstr "Visualizzazione"
+
+msgid "Warning"
+msgstr "Attenzione"
 
 msgid "edit network attributes"
 msgstr "modifica gli attributi della rete"

--- a/src/main/po/ru.po
+++ b/src/main/po/ru.po
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_matsim v0.9.0\n"
+"Project-Id-Version: josm-plugin_matsim v0.9.0-4-ge4ee56c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-23 10:15+0000\n"
+"POT-Creation-Date: 2018-05-25 11:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: Russian (https://www.transifex.com/josm/teams/2544/ru/)\n"
 "MIME-Version: 1.0\n"
@@ -16,6 +16,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+
+msgid "Check for Incomplete Routes"
+msgstr "Проверить на неполные маршруты"
+
+msgid "Clean Network"
+msgstr "Очистить сеть"
 
 msgid "Click to download the currently selected area"
 msgstr "Щёлкните, чтобы скачать текущую выделенную область"
@@ -70,9 +76,6 @@ msgstr "Меню: {0}"
 msgid "Network Attributes"
 msgstr "Атрибуты сети"
 
-msgid "New MATSim Network"
-msgstr "Новая сеть MATSim"
-
 msgid "New MATSim network"
 msgstr "Новая сеть MATSim"
 
@@ -90,6 +93,9 @@ msgstr "Симуляция"
 
 msgid "Visualization"
 msgstr "Визуализация"
+
+msgid "Warning"
+msgstr "Предупреждение"
 
 msgid "edit network attributes"
 msgstr "изменить атрибуты сети"


### PR DESCRIPTION
Update `gradle-josm-plugin` and `josm`.

Update JUnit to major version 5. Tests for JUnit API 4 can be migrated step by step to the new API and AFAIK mixed freely with JUnit 5 tests.

The version number is now automatically set from the git-tags since `v0.4.8` of the gradle plugin.

The translations are the current state from Transifex.