### PR TITLE
Update JOSM compile version to be compatible with josm-unittest

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -3,6 +3,8 @@ host = https://www.transifex.com
 
 [josm.josm-plugin_matsim]
 file_filter = src/main/po/<lang>.po
+lang_map = ca@valencia: ca-valencia
+minimum_perc=40
 source_file = build/i18n/josm-plugin_matsim.pot
 source_lang = en
 type = PO

--- a/build.gradle
+++ b/build.gradle
@@ -42,12 +42,14 @@ dependencies {
     testRuntimeOnly ("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
     testImplementation ("org.junit.vintage:junit-vintage-engine:$junitVersion")
     testImplementation ('org.openstreetmap.josm:josm-unittest:') {changing = true}
+    testImplementation ("com.github.tomakehurst:wiremock:2.18.0")
+    testImplementation ("org.awaitility:awaitility:3.1.2")
 }
 
 sourceCompatibility = 1.8
 archivesBaseName = "matsim"
 josm {
-    josmCompileVersion = 13922
+    josmCompileVersion = 14053
     manifest {
         author = "Nico Kuehnel"
         description = "Allows to edit and extract network information for the traffic simulation MATSim"
@@ -65,6 +67,12 @@ josm {
     i18n {
       pathTransformer = getPathTransformer("github.com/matsim-org/josm-matsim-plugin/blob")
     }
+}
+
+tasks.withType(JavaCompile) {
+  options.compilerArgs += [
+    "-Xlint:deprecation"
+  ]
 }
 
 tasks.test.outputs.dir("$buildDir/test-output")

--- a/src/main/po/de.po
+++ b/src/main/po/de.po
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_matsim v0.9.0-4-ge4ee56c\n"
+"Project-Id-Version: josm-plugin_matsim v0.9.3-1-g5f14357\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-25 11:30+0000\n"
+"POT-Creation-Date: 2018-06-26 15:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: German (https://www.transifex.com/josm/teams/2544/de/)\n"
 "MIME-Version: 1.0\n"

--- a/src/main/po/el.po
+++ b/src/main/po/el.po
@@ -1,0 +1,224 @@
+# Translations for the JOSM plugin 'matsim' (el)
+# Copyright (C) 2018 
+# This file is distributed under the same license as the josm-plugin_matsim package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: josm-plugin_matsim v0.9.3-1-g5f14357\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-26 15:50+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Language-Team: Greek (https://www.transifex.com/josm/teams/2544/el/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: el\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. Visualization
+msgid "Activate MATSim Renderer"
+msgstr "Ενεργοποίηση της Απόδοσης MATSim"
+
+msgid "Activate hierarchy filter"
+msgstr "Ενεργοποίηση του φίλτρου ιεραρχίας"
+
+msgid "Check for Incomplete Routes"
+msgstr "Έλεγχος για ημιτελείς Διαδρομές"
+
+msgid "Click to download the currently selected area"
+msgstr "Κάντε κλικ για λήψη της τρέχουσας επιλεγμένης περιοχής"
+
+msgid "Configure the MATSim plugin."
+msgstr "Ρύθμιση του πρόσθετου MATSim."
+
+msgid "Contacting OSM Server..."
+msgstr "Επικοινωνία με τον διακομιστή OSM"
+
+msgid "Convert Osm layer to MATSim network layer"
+msgstr "Μετατροπή του επιπέδου Osm στο επίπεδο δικτύου MATSim"
+
+msgid "Convert to MATSim Layer"
+msgstr "Μετατροπή στο επίπεδο MATSim"
+
+msgid "Convert to MATSim Network"
+msgstr "Μετατροπή στο δίκτυο MATSim"
+
+msgid "Converter"
+msgstr "Μετατροπή"
+
+msgid "Create Master Routes"
+msgstr "Δημιουργία Κύριων Διαδρομών"
+
+msgid "Create areas for public transport stops"
+msgstr "Δημιουργία χώρων για στάσεις δημόσιων συγκοινωνιών"
+
+msgid "Create new Network"
+msgstr "Δημιουργία νέου Δικτύου"
+
+msgid "Defaults"
+msgstr "Προεπιλογές"
+
+msgid "Download"
+msgstr "Λήψη"
+
+msgid "Download VBB…"
+msgstr "Λήψη VBB…"
+
+msgid "Download data from Overpass API, filtered by relevance for MATSim."
+msgstr ""
+"Λήψη δεδομένων από το API Overpass, φιλτραρισμένο με σχετικότητα για το "
+"MATSim."
+
+msgid "Download from Overpass API..."
+msgstr "Λήψη από το Overpass API..."
+
+msgid "Download members and stop areas"
+msgstr "Λήψη μελών και χώροι στάσεων"
+
+#. create error with message
+#. create warning with message
+#, java-format
+msgid "Duplicated Id {0} not allowed."
+msgstr "Διπλό αναγνωριστικό {0} δεν επιτρέπεται."
+
+msgid "Export MATSim network to shape file..."
+msgstr "Εξαγωγή δικτύου MATSim σε αρχείο shapefile..."
+
+msgid "Export MATSim network to shape file…"
+msgstr "Εξαγωγή δικτύου MATSim σε αρχείο shapefile..."
+
+msgid "Export MATSim transit schedule…"
+msgstr "Εξαγωγή προγράμματος μεταφοράς MATSim..."
+
+msgid ""
+"Export failed due to validation errors. See validation layer for details."
+msgstr ""
+"Η εξαγωγή απέτυχε λόγω σφαλμάτων επικύρωσης. Δείτε το επίπεδο επικύρωσης για"
+" λεπτομέρειες."
+
+#. General
+msgid "Exported network xml version"
+msgstr "Εξαγόμενη έκδοση δικτύου xml"
+
+msgid "Failure"
+msgstr "Αποτυχία"
+
+msgid "Fix transit schedule validation errors"
+msgstr "Επίλυση σφαλμάτων επικύρωσης προγράμματος μεταφοράς"
+
+msgid "General"
+msgstr "Γενικά"
+
+msgid "Import"
+msgstr "Εισαγωγή"
+
+msgid "Import MATSim scenario"
+msgstr "Εισαγωγή σεναρίου MATSim"
+
+msgid "Include road type in output"
+msgstr "Συμπεριλάβετε τον τύπο δρόμου στην έξοδο"
+
+#, java-format
+msgid ""
+"Incomplete route {0} - Auto repair to download missing elements (cannot be "
+"undone)"
+msgstr ""
+"Ελλιπής διαδρομή {0} - Αυτόματη επιδιόρθωση για λήψη στοιχείων που λείπουν "
+"(δεν μπορούν να ανακληθούν)"
+
+msgid "Information"
+msgstr "Πληροφορίες"
+
+msgid "Keep Paths"
+msgstr "Διατήρηση Διαδρομών"
+
+#, java-format
+msgid "Lines: {0} / Routes: {1}"
+msgstr "Γραμμές: {0} / Διαδρομές: {1}"
+
+msgid "Link offset for overlapping links"
+msgstr "Μετατόπιση συνδέσμου για επικαλυπτόμενες συνδέσεις"
+
+msgid "Links/Nodes"
+msgstr "Σύνδεσμοι/Κόμβοι"
+
+#, java-format
+msgid "Links: {0} / Nodes: {1}"
+msgstr "Σύνδεσμοι: {0} / Κόμβοι: {1}"
+
+msgid "MASim preferences"
+msgstr "Προτιμήσεις MASim"
+
+msgid "MATSim"
+msgstr "MASim"
+
+msgid "MATSim Import"
+msgstr "Εισαγωγή MATSim"
+
+msgid "MATSim Transit Schedule Files"
+msgstr "Αρχεία Προγραμματισμού Μεταφοράς MATSim"
+
+msgid "MATSimValidation"
+msgstr "Επικύρωση MATSim"
+
+#, java-format
+msgid "Menu: {0}"
+msgstr "Μενού: {0}"
+
+msgid "Network Attributes"
+msgstr "Χαρακτηριστικά Δικτύου"
+
+msgid "New MATSim network"
+msgstr "Νέο δίκτυο MATSim"
+
+msgid "No MATSim layer active"
+msgstr "Κανένα ενεργό επίπεδο MATSim"
+
+msgid "Nothing to export. Get some data first."
+msgstr "Τίποτα προς εξαγωγή. Λάβετε κάποια δεδομένα πρώτα."
+
+msgid "OSM Repair"
+msgstr "Επισκευή OSM"
+
+msgid "Only convert hierarchies up to: "
+msgstr "Μετατρέψτε μόνο ιεραρχίες μέχρι:"
+
+#, java-format
+msgid "Route {0} with no Route Master"
+msgstr "Διαδρομή {0} χωρίς Κύρια Διαδρομή"
+
+msgid "Save MATSim network file"
+msgstr "Αποθήκευση του αρχείου δικτύου MATSim"
+
+#, java-format
+msgid "Select to download {0} highways in the selected download area."
+msgstr ""
+"Επιλέξτε για να κάνετε λήψη {0} δρόμους στην επιλεγμένη περιοχή λήψης."
+
+#, java-format
+msgid "Select to download {0} routes in the selected download area."
+msgstr ""
+"Επιλέξτε για να κάνετε λήψη {0} διαδρομών στην επιλεγμένη περιοχή λήψης."
+
+msgid "Shape Files"
+msgstr "Shape Files"
+
+msgid "Simulate"
+msgstr "Προσομοίωση"
+
+msgid "Test for incomplete routes"
+msgstr "Δοκιμή για ημιτελείς διαδρομές"
+
+msgid "Test for master routes"
+msgstr "Δοκιμή για κύριες διαδρομές"
+
+msgid "Visualization"
+msgstr "Οπτικοποίηση"
+
+msgid "Warning"
+msgstr "Προειδοποίηση"
+
+msgid "edit network attributes"
+msgstr "επεξεργασία χαρακτηριστικών δικτύου"

--- a/src/main/po/it.po
+++ b/src/main/po/it.po
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_matsim v0.9.0-4-ge4ee56c\n"
+"Project-Id-Version: josm-plugin_matsim v0.9.3-1-g5f14357\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-25 11:30+0000\n"
+"POT-Creation-Date: 2018-06-26 15:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: Italian (https://www.transifex.com/josm/teams/2544/it/)\n"
 "MIME-Version: 1.0\n"

--- a/src/main/po/pl.po
+++ b/src/main/po/pl.po
@@ -1,0 +1,260 @@
+# Translations for the JOSM plugin 'matsim' (pl)
+# Copyright (C) 2018 
+# This file is distributed under the same license as the josm-plugin_matsim package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: josm-plugin_matsim v0.9.3-1-g5f14357\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-26 15:50+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Language-Team: Polish (https://www.transifex.com/josm/teams/2544/pl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: pl\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+
+#. Visualization
+msgid "Activate MATSim Renderer"
+msgstr "Aktywuj renderer MATSim"
+
+msgid "Activate hierarchy filter"
+msgstr "Aktywuj filtr hierarchii"
+
+msgid "Check for Incomplete Routes"
+msgstr "Sprawdź niekompletne trasy"
+
+msgid "Clean Network"
+msgstr "Wyczyść sieć"
+
+msgid "Click to download the currently selected area"
+msgstr "Kliknij aby pobrać wybrany obszar"
+
+msgid "Configure the MATSim plugin."
+msgstr "Konfiguruj wtyczkę MATSim"
+
+msgid "Contacting OSM Server..."
+msgstr "Łączenie z serwerem OSM..."
+
+msgid "Convert Osm layer to MATSim network layer"
+msgstr "Przekształć warstwę OSM w warstwę sieci MATSim"
+
+msgid "Convert to MATSim Layer"
+msgstr "Przekształć w warstwę MATSim"
+
+msgid "Convert to MATSim Network"
+msgstr "Przekształć w sieć MATSim"
+
+msgid "Converter"
+msgstr "Konwerter"
+
+msgid "Create Master Routes"
+msgstr "Utwórz główne trasy"
+
+msgid "Create areas for public transport stops"
+msgstr "Utwórz obszary dla przystanków transportu publicznego"
+
+msgid "Create new Network"
+msgstr "Utwórz nową sieć"
+
+msgid "Defaults"
+msgstr "Domyślne"
+
+msgid "Download"
+msgstr "Pobierz"
+
+msgid "Download VBB…"
+msgstr "Pobieranie VBB…"
+
+msgid "Download data from Overpass API, filtered by relevance for MATSim."
+msgstr ""
+"Pobierz dane z Overpass API, przefiltrowane pod kątem użyteczności w MATSim."
+
+msgid "Download from Overpass API..."
+msgstr "Pobieranie z API Overpass..."
+
+msgid "Download members and stop areas"
+msgstr "Pobierz członków i obszary przystanków"
+
+#. create error with message
+#. create warning with message
+#, java-format
+msgid "Duplicated Id {0} not allowed."
+msgstr "Nie jest dopuszczone duplikowanie Id {0}."
+
+msgid "Export MATSim network to shape file..."
+msgstr "Eksportuj sieć MATSim do pliku kształtu..."
+
+msgid "Export MATSim network to shape file…"
+msgstr "Eksportuj sieć MATSim do pliku kształtu..."
+
+msgid "Export MATSim transit schedule…"
+msgstr "Eksportuj rozkład MATSim..."
+
+msgid ""
+"Export failed due to validation errors. See validation layer for details."
+msgstr ""
+"Eksport nieudany ze względu na błędy weryfikacji. Zobacz warstwę "
+"weryfikacji, aby uzyskać więcej szczegółów."
+
+#. General
+msgid "Exported network xml version"
+msgstr "Sieć wyeksportowana do wersji xml"
+
+msgid "Failure"
+msgstr "Błąd"
+
+msgid "Fix transit schedule validation errors"
+msgstr "Rozwiąż błędy weryfikacji rozkładów"
+
+msgid "General"
+msgstr "Ogólne"
+
+msgid "Import"
+msgstr "Import"
+
+msgid "Import MATSim scenario"
+msgstr "Importuj scenariusz MATSim"
+
+msgid "Include road type in output"
+msgstr "Dołącz rodzaje dróg do wyjścia"
+
+#, java-format
+msgid ""
+"Incomplete route {0} - Auto repair to download missing elements (cannot be "
+"undone)"
+msgstr ""
+"Niekompletna trasa {0} - użyj automatycznej naprawy, aby pobrać brakujące "
+"elementy (nie można cofnąć)"
+
+msgid "Information"
+msgstr "Informacje"
+
+msgid "Keep Paths"
+msgstr "Zachowaj ścieżki"
+
+#, java-format
+msgid "Lines: {0} / Routes: {1}"
+msgstr "Linie: {0} / Trasy: {1}"
+
+msgid "Link offset for overlapping links"
+msgstr "Przesunięcie dla nakładających się linków"
+
+msgid "Links/Nodes"
+msgstr "Linki/Węzły"
+
+#, java-format
+msgid "Links: {0} / Nodes: {1}"
+msgstr "Linki: {0} / Węzły: {1}"
+
+msgid "MASim preferences"
+msgstr "Preferencje MATSim"
+
+msgid "MATSim"
+msgstr "MATSim"
+
+msgid "MATSim Import"
+msgstr "Importuj MATSim"
+
+msgid "MATSim Transit Schedule Files"
+msgstr "MATSim Transit Schedule Files"
+
+msgid "MATSimValidation"
+msgstr "MATSimValidation"
+
+#, java-format
+msgid "Menu: {0}"
+msgstr "Menu: {0}"
+
+msgid "Network Attributes"
+msgstr "Właściwości sieci"
+
+msgid "New MATSim network"
+msgstr "Nowa sieć MATSim"
+
+msgid "No MATSim layer active"
+msgstr "Warstwa MATSim nie jest aktywna"
+
+msgid "Nothing to export. Get some data first."
+msgstr "Nie ma nic do wyeksportowania. Utwórz jakieś obiekty."
+
+msgid "OSM Repair"
+msgstr "Naprawa OSM"
+
+msgid "Only convert hierarchies up to: "
+msgstr "Przekształcaj tylko hierarchie do: "
+
+#, java-format
+msgid "Route {0} with no Route Master"
+msgstr "Trasa {0} nie zawiera głównej trasy"
+
+msgid "Save MATSim network file"
+msgstr "Zapisz plik sieci MATSim"
+
+#, java-format
+msgid "Select to download {0} highways in the selected download area."
+msgstr "Wybierz, aby pobrać {0} dróg w zaznaczonym obszarze."
+
+#, java-format
+msgid "Select to download {0} routes in the selected download area."
+msgstr "Wybierz, aby pobrać {0} tras w zaznaczonym obszarze."
+
+msgid "Set conversion defaults"
+msgstr "Ustaw wartości domyślne konwersji"
+
+msgid "Shape Files"
+msgstr "Pliki kształtu"
+
+msgid "Show internal Ids in table"
+msgstr "Pokaż wewnętrzne Ids w tabeli"
+
+msgid "Show link-Ids"
+msgstr "Pokaż linki Ids"
+
+msgid "Simulate"
+msgstr "Symuluj"
+
+msgid "Test for incomplete routes"
+msgstr "Testuj niekompletne trasy"
+
+msgid "Test for master routes"
+msgstr "Sprawdź główne trasy"
+
+msgid "Update tags for public transport stops"
+msgstr "Aktualizacja znaczników dla przystanków transportu publicznego"
+
+msgid "Validate TransitSchedule"
+msgstr "Weryfikuj TransitSchedule"
+
+msgid "Validates MATSim-related network data"
+msgstr "Weryfikuj dane sieci powiązane z MATSim"
+
+msgid "Validates MATSim-related transit schedule data"
+msgstr "Weryfikuj dane rozkładów powiązane z MATSim"
+
+msgid ""
+"Validaton resulted in warnings.\n"
+" Proceed?"
+msgstr ""
+"Weryfikacja zakończona z błędami.\n"
+" Kontynuować?"
+
+msgid "Visualization"
+msgstr "Wizualizacja"
+
+msgid "Warning"
+msgstr "Ostrzeżenie"
+
+msgid "edit network attributes"
+msgstr "edytuj właściwości sieci"
+
+#. Plugin description for josm-matsim-plugin
+msgid ""
+"Allows to edit and extract network information for the traffic simulation "
+"MATSim"
+msgstr ""
+"Pozwala na edycję i wydobycie informacji o sieci dla potrzeb symulacji ruchu"
+" MATSim"

--- a/src/main/po/ru.po
+++ b/src/main/po/ru.po
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: josm-plugin_matsim v0.9.0-4-ge4ee56c\n"
+"Project-Id-Version: josm-plugin_matsim v0.9.3-1-g5f14357\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-25 11:30+0000\n"
+"POT-Creation-Date: 2018-06-26 15:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: Russian (https://www.transifex.com/josm/teams/2544/ru/)\n"
 "MIME-Version: 1.0\n"
@@ -16,6 +16,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+
+#. Visualization
+msgid "Activate MATSim Renderer"
+msgstr "Активировать отрисовщик MATSim"
+
+msgid "Activate hierarchy filter"
+msgstr "Активировать фильтр иерархии"
 
 msgid "Check for Incomplete Routes"
 msgstr "Проверить на неполные маршруты"
@@ -47,8 +54,30 @@ msgstr "Конвертер"
 msgid "Create new Network"
 msgstr "Создать новую сеть"
 
+msgid "Download data from Overpass API, filtered by relevance for MATSim."
+msgstr ""
+"Скачать данные с Overpass API, отфильтрованные по значимости для MATSim."
+
 msgid "Download from Overpass API..."
 msgstr "Скачать с Overpass API..."
+
+msgid "Download members and stop areas"
+msgstr "Скачать участников и остановочные зоны"
+
+#. create error with message
+#. create warning with message
+#, java-format
+msgid "Duplicated Id {0} not allowed."
+msgstr "Дублирование Id {0} запрещено."
+
+msgid ""
+"Export failed due to validation errors. See validation layer for details."
+msgstr ""
+"Сбой экспорта из-за ошибок валидации. Подробнее смотрите в слое результатов "
+"проверки."
+
+msgid "Failure"
+msgstr "Ошибка"
 
 msgid "Import"
 msgstr "Импортировать"
@@ -69,6 +98,9 @@ msgstr "Настройки MASim"
 msgid "MATSim"
 msgstr "MATSim"
 
+msgid "MATSim Import"
+msgstr "Импорт MATSim"
+
 #, java-format
 msgid "Menu: {0}"
 msgstr "Меню: {0}"
@@ -88,8 +120,17 @@ msgstr "Нечего экспортировать. Сначала получит
 msgid "Save MATSim network file"
 msgstr "Сохранить файл сети MATSim"
 
+msgid "Show internal Ids in table"
+msgstr "Показывать внутренние Id в таблице"
+
 msgid "Simulate"
 msgstr "Симуляция"
+
+msgid "Test for incomplete routes"
+msgstr "Проверка на неполные маршруты"
+
+msgid "Update tags for public transport stops"
+msgstr "Обновить теги для остановок общественного транспорта"
 
 msgid "Visualization"
 msgstr "Визуализация"


### PR DESCRIPTION
Same reasoning as for https://github.com/JOSM/pt_assistant/pull/4 , snapshot dependency `josm-unittest` changed incompatibly and made the CI fail.

Edit: Also adds new translations.