### PR TITLE
Make matsim plugin depend on new 'openjfx' plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ josm {
         iconPath = "images/dialogs/matsim-scenario.png"
         minJosmVersion = 13922
         mainClass = "org.matsim.contrib.josm.MATSimPlugin"
-        pluginDependencies << 'jts' << 'apache-commons' << 'apache-http' << 'geotools'
+        pluginDependencies << 'jts' << 'apache-commons' << 'apache-http' << 'geotools' << 'openjfx'
         website = new URL("http://www.matsim.org")
         oldVersionDownloadLink 13878, 'v0.9.2', new URL('https://github.com/matsim-org/josm-matsim-plugin/releases/download/v0.9.2/matsim.jar')
         oldVersionDownloadLink 12881, 'v0.8.8', new URL('https://github.com/matsim-org/josm-matsim-plugin/releases/download/v0.8.8/matsim.jar')


### PR DESCRIPTION
See https://josm.openstreetmap.de/ticket/16682
A new plugin is required to ship JavaFX for Java >= 11. This is done. The plugin has no effect on Java <= 10.