### PR TITLE
Add HBEFA Road Type in JOSM

### DIFF
--- a/josm-matsim-plugin.iml
+++ b/josm-matsim-plugin.iml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id="josm-matsim-plugin" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="v0.9.5-dirty" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/out" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/main/java/org/matsim/contrib/josm/gui/LinksToggleDialog.java
+++ b/src/main/java/org/matsim/contrib/josm/gui/LinksToggleDialog.java
@@ -184,7 +184,7 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 	// handles the underlying data of the links table
 	private class MATSimTableModel_links extends AbstractTableModel implements SelectionChangedListener, ListSelectionListener {
 
-		private final String[] columnNames = { "id", "internal-id", "length", "freespeed", "capacity", "permlanes", "modes", "type" };
+		private final String[] columnNames = { "id", "internal-id", "length", "freespeed", "capacity", "permlanes", "modes", "type", "hbefa" };
 
 		private Map<Integer, MLink> links;
 
@@ -210,6 +210,8 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 			} else if (columnIndex == 6) {
 				return String.class;
 			} else if (columnIndex == 7) {
+				return String.class;
+			} else if (columnIndex == 8) {
 				return String.class;
 			}
 			throw new RuntimeException();
@@ -250,6 +252,8 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 			} else if (columnIndex == 7) {
 				return link.getType();
 			} else if (columnIndex == 8) {
+				return link.getHbefaType();
+			} else if(columnIndex == 9) {
 				return link;
 			}
 			throw new RuntimeException();
@@ -288,7 +292,7 @@ public class LinksToggleDialog extends ToggleDialog implements ActiveLayerChange
 			if (currentDataSet != null) {
 				if (table_links.getSelectedRow() != -1) {
 					int row = table_links.convertRowIndexToModel(table_links.getSelectedRow());
-					MLink link = (MLink) this.getValueAt(row, 8);
+					MLink link = (MLink) this.getValueAt(row, 9);
 					if (link.getSegments() != null) {
 						List<WaySegment> segments = link.getSegments();
 						currentDataSet.setHighlightedWaySegments(segments);

--- a/src/main/java/org/matsim/contrib/josm/model/Export.java
+++ b/src/main/java/org/matsim/contrib/josm/model/Export.java
@@ -48,7 +48,8 @@ public class Export {
 				newLink.setNumberOfLanes(link.getNumberOfLanes());
 				newLink.setAllowedModes(link.getAllowedModes());
 				if (Preferences.includeRoadType()) {
-					EmissionUtils.setHbefaRoadType(newLink,link.getType());
+					NetworkUtils.setType(newLink, link.getType());
+					EmissionUtils.setHbefaRoadType(newLink, link.getHbefaType());
 				}
 				scenario.getNetwork().addLink(newLink);
 			}

--- a/src/main/java/org/matsim/contrib/josm/model/Importer.java
+++ b/src/main/java/org/matsim/contrib/josm/model/Importer.java
@@ -1,8 +1,10 @@
 package org.matsim.contrib.josm.model;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.contrib.emissions.utils.EmissionUtils;
 import org.matsim.contrib.josm.gui.Preferences;
@@ -115,9 +117,10 @@ public class Importer {
 			way.put(LinkConversionRules.LENGTH, String.valueOf(link.getLength()));
 			way.put(LinkConversionRules.PERMLANES, String.valueOf(link.getNumberOfLanes()));
 
-			  if (EmissionUtils.getHbefaRoadType(link)!=null){
-                way.put(LinkConversionRules.TYPE, String.valueOf(EmissionUtils.getHbefaRoadType(link)));
-			}
+			  if (NetworkUtils.getType(link)!= null){
+			  	way.put(LinkConversionRules.TYPE, String.valueOf(NetworkUtils.getType(link)));
+			  	way.put(LinkConversionRules.HBEFA, String.valueOf(EmissionUtils.getHbefaRoadType(link)));
+			  }
 
 			StringBuilder modes = new StringBuilder();
 			for (String mode : link.getAllowedModes()) {

--- a/src/main/java/org/matsim/contrib/josm/model/LinkConversionRules.java
+++ b/src/main/java/org/matsim/contrib/josm/model/LinkConversionRules.java
@@ -11,208 +11,240 @@ import java.util.Set;
 
 public class LinkConversionRules {
 
-	public static final String ID = "matsim:id";
-	public static final String FREESPEED = "matsim:freespeed";
-	public static final String PERMLANES = "matsim:permlanes";
-	public static final String CAPACITY = "matsim:capacity";
-	public static final String MODES = "matsim:modes";
-	public static final String LENGTH = "matsim:length";
-	public static final String TYPE = "matsim:type";
+    public static final String ID = "matsim:id";
+    public static final String FREESPEED = "matsim:freespeed";
+    public static final String PERMLANES = "matsim:permlanes";
+    public static final String CAPACITY = "matsim:capacity";
+    public static final String MODES = "matsim:modes";
+    public static final String LENGTH = "matsim:length";
+    public static final String TYPE = "matsim:type";
+    public static final String HBEFA = "matsim:hbefa";
 
-	static String getId(Way way, long increment, boolean backward) {
-		return String.valueOf(way.getUniqueId()) + "_" + increment + (backward ? "_r" : "");
-	}
+    static String getId(Way way, long increment, boolean backward) {
+        return String.valueOf(way.getUniqueId()) + "_" + increment + (backward ? "_r" : "");
+    }
 
-	static String getOrigId(Way way, String id, boolean backward) {
-		String origId;
-		if (way.hasKey(ID)) {
-			origId = way.get(ID) + (backward ? "_r" : "");
-		} else {
-			origId = id;
-		}
-		return origId;
-	}
+    static String getOrigId(Way way, String id, boolean backward) {
+        String origId;
+        if (way.hasKey(ID)) {
+            origId = way.get(ID) + (backward ? "_r" : "");
+        } else {
+            origId = id;
+        }
+        return origId;
+    }
 
-	static boolean isBackward(Way way, OsmConvertDefaults.OsmWayDefaults defaults) {
-		boolean backward;
-		if (defaults != null) {
-			backward = !defaults.oneway;
-			if (way.hasTag("oneway", "yes", "true", "1")) {
-				backward = false;
-			} else if (way.hasTag("oneway", "-1")) {
-				backward = true;
-			} else if (way.hasTag("oneway", "no")) {
-				backward = true;
-			}
-			if (defaults.hierarchy > Preferences.getMatsimFilterHierarchy()) {
-				backward = false;
-			}
-			if (way.hasTag("access", "no")) {
-				backward = false;
-			}
-		} else {
-			backward = false;
-		}
-		return backward;
-	}
+    static boolean isBackward(Way way, OsmConvertDefaults.OsmWayDefaults defaults) {
+        boolean backward;
+        if (defaults != null) {
+            backward = !defaults.oneway;
+            if (way.hasTag("oneway", "yes", "true", "1")) {
+                backward = false;
+            } else if (way.hasTag("oneway", "-1")) {
+                backward = true;
+            } else if (way.hasTag("oneway", "no")) {
+                backward = true;
+            }
+            if (defaults.hierarchy > Preferences.getMatsimFilterHierarchy()) {
+                backward = false;
+            }
+            if (way.hasTag("access", "no")) {
+                backward = false;
+            }
+        } else {
+            backward = false;
+        }
+        return backward;
+    }
 
-	static boolean isForward(Way way, OsmConvertDefaults.OsmWayDefaults defaults) {
-		boolean forward;
-		if (defaults != null) {
-			if (defaults.oneway) {
-				forward = true;
-			} else {
-				forward = true;
-			}
+    static boolean isForward(Way way, OsmConvertDefaults.OsmWayDefaults defaults) {
+        boolean forward;
+        if (defaults != null) {
+            if (defaults.oneway) {
+                forward = true;
+            } else {
+                forward = true;
+            }
 
-			if (way.hasTag("oneway", "yes", "true", "1")) {
-				forward = true;
-			} else if (way.hasTag("oneway", "-1")) {
-				forward = false;
-			} else if (way.hasTag("oneway", "no")) {
-				forward = true;
-			}
-			if (defaults.hierarchy > Preferences.getMatsimFilterHierarchy()) {
-				forward = false;
-			}
-			if (way.hasTag("access", "no")) {
-				forward = false;
-			}
-		} else {
-			forward = true;
-		}
-		return forward;
-	}
+            if (way.hasTag("oneway", "yes", "true", "1")) {
+                forward = true;
+            } else if (way.hasTag("oneway", "-1")) {
+                forward = false;
+            } else if (way.hasTag("oneway", "no")) {
+                forward = true;
+            }
+            if (defaults.hierarchy > Preferences.getMatsimFilterHierarchy()) {
+                forward = false;
+            }
+            if (way.hasTag("access", "no")) {
+                forward = false;
+            }
+        } else {
+            forward = true;
+        }
+        return forward;
+    }
 
-	static Set<String> getModes(Way way, OsmConvertDefaults.OsmWayDefaults defaults) {
-		Set<String> modes = null;
-		if (way.getKeys().containsKey(MODES)) {
-			modes = new HashSet<>(Arrays.asList(way.getKeys().get(MODES).split(";")));
-		}
-		if (defaults != null) {
-			if (modes == null) {
-				modes = new HashSet<>();
-				if (way.getKeys().containsKey(NetworkModel.TAG_RAILWAY)) {
-					modes.add(TransportMode.pt);
-				}
-				if (way.getKeys().containsKey(NetworkModel.TAG_HIGHWAY)) {
-					modes.add(TransportMode.car);
-				}
-			}
-		}
-		return modes;
-	}
+    static Set<String> getModes(Way way, OsmConvertDefaults.OsmWayDefaults defaults) {
+        Set<String> modes = null;
+        if (way.getKeys().containsKey(MODES)) {
+            modes = new HashSet<>(Arrays.asList(way.getKeys().get(MODES).split(";")));
+        }
+        if (defaults != null) {
+            if (modes == null) {
+                modes = new HashSet<>();
+                if (way.getKeys().containsKey(NetworkModel.TAG_RAILWAY)) {
+                    modes.add(TransportMode.pt);
+                }
+                if (way.getKeys().containsKey(NetworkModel.TAG_HIGHWAY)) {
+                    modes.add(TransportMode.car);
+                }
+            }
+        }
+        return modes;
+    }
 
-	static Double getCapacity(Way way, OsmConvertDefaults.OsmWayDefaults defaults, Double nofLanesPerDirection) {
-		Double capacity = null;
-		if (way.getKeys().containsKey(CAPACITY)) {
-			capacity = parseDoubleIfPossible(way.getKeys().get(CAPACITY));
-		}
-		if (defaults != null) {
-			if (capacity == null) {
-				capacity = nofLanesPerDirection * defaults.laneCapacity;
-			}
-		}
-		return capacity;
-	}
+    static Double getCapacity(Way way, OsmConvertDefaults.OsmWayDefaults defaults, Double nofLanesPerDirection) {
+        Double capacity = null;
+        if (way.getKeys().containsKey(CAPACITY)) {
+            capacity = parseDoubleIfPossible(way.getKeys().get(CAPACITY));
+        }
+        if (defaults != null) {
+            if (capacity == null) {
+                capacity = nofLanesPerDirection * defaults.laneCapacity;
+            }
+        }
+        return capacity;
+    }
 
-	static Double getLanesPerDirection(Way way, OsmConvertDefaults.OsmWayDefaults defaults, boolean forward, boolean backward) {
-		Double nofLanesPerDirection = null;
-		if (way.getKeys().containsKey(PERMLANES)) {
-			nofLanesPerDirection = parseDoubleIfPossible(way.getKeys().get(PERMLANES));
-		}
-		if (defaults != null) {
-			if (nofLanesPerDirection == null) {
-				nofLanesPerDirection = defaults.lanesPerDirection;
-				if (way.getKeys().containsKey("lanes")) {
-					Double noOfLanes = parseDoubleIfPossible(way.getKeys().get("lanes"));
-					if (noOfLanes != null) {
-						if (forward && backward) {
-							nofLanesPerDirection = noOfLanes / 2.0;
-						} else {
-							nofLanesPerDirection = noOfLanes;
-						}
-					}
-				}
-			}
-		}
-		return nofLanesPerDirection;
-	}
+    static Double getLanesPerDirection(Way way, OsmConvertDefaults.OsmWayDefaults defaults, boolean forward, boolean backward) {
+        Double nofLanesPerDirection = null;
+        if (way.getKeys().containsKey(PERMLANES)) {
+            nofLanesPerDirection = parseDoubleIfPossible(way.getKeys().get(PERMLANES));
+        }
+        if (defaults != null) {
+            if (nofLanesPerDirection == null) {
+                nofLanesPerDirection = defaults.lanesPerDirection;
+                if (way.getKeys().containsKey("lanes")) {
+                    Double noOfLanes = parseDoubleIfPossible(way.getKeys().get("lanes"));
+                    if (noOfLanes != null) {
+                        if (forward && backward) {
+                            nofLanesPerDirection = noOfLanes / 2.0;
+                        } else {
+                            nofLanesPerDirection = noOfLanes;
+                        }
+                    }
+                }
+            }
+        }
+        return nofLanesPerDirection;
+    }
 
-	static Double getFreespeed(Way way, OsmConvertDefaults.OsmWayDefaults defaults) {
-		Double freespeed = null;
-		if (way.getKeys().containsKey(FREESPEED)) {
-			freespeed = parseDoubleIfPossible(way.getKeys().get(FREESPEED));
-		}
-		if (freespeed == null) {
-			if (defaults != null) {
-				freespeed = defaults.freespeed;
-				if (way.getKeys().containsKey("maxspeed")) {
-					Double maxspeedInKmH = parseDoubleIfPossible(way.getKeys().get("maxspeed"));
-					if (maxspeedInKmH != null) {
-						freespeed = maxspeedInKmH / 3.6; // convert km/h to m/s
-					}
-				}
-			}
-		}
-		return freespeed;
-	}
+    static Double getFreespeed(Way way, OsmConvertDefaults.OsmWayDefaults defaults) {
+        Double freespeed = null;
+        if (way.getKeys().containsKey(FREESPEED)) {
+            freespeed = parseDoubleIfPossible(way.getKeys().get(FREESPEED));
+        }
+        if (freespeed == null) {
+            if (defaults != null) {
+                freespeed = defaults.freespeed;
+                if (way.getKeys().containsKey("maxspeed")) {
+                    Double maxspeedInKmH = parseDoubleIfPossible(way.getKeys().get("maxspeed"));
+                    if (maxspeedInKmH != null) {
+                        freespeed = maxspeedInKmH / 3.6; // convert km/h to m/s
+                    }
+                }
+            }
+        }
+        return freespeed;
+    }
 
 
-	static String getType(Way way, OsmConvertDefaults.OsmWayDefaults defaults) {
-		String type = null;
-		if (way.getKeys().containsKey(TYPE)) {
-			type = way.getKeys().get(TYPE);
-		}
-		if (type == null) {
-			if (way.getKeys().containsKey("highway")) {
-				type = way.getKeys().get("highway");
-				Double freespeed = getFreespeed(way, defaults);
-				if (type != null && freespeed != null) {
-					type = String.format("%s_%d", type, Math.round(freespeed * 3.6));
-				}
-			}
+    static String getType(Way way, OsmConvertDefaults.OsmWayDefaults defaults) {
+        String type = null;
+        if (way.getKeys().containsKey(TYPE)) {
+            type = way.getKeys().get(TYPE);
+        }
+        if (type == null) {
+            if (way.getKeys().containsKey("highway")) {
+                type = way.getKeys().get("highway");
+                Double freespeed = getFreespeed(way, defaults);
+                if (type != null && freespeed != null) {
+                    type = String.format("%s_%d", type, Math.round(freespeed * 3.6));
+                }
+            }
 
-		}
-		return type;
-	}
+        }
+        return type;
+    }
 
-	static boolean isMatsimWay(Way way) {
-		final OsmConvertDefaults.OsmWayDefaults defaults = getWayDefaults(way);
+    static boolean isMatsimWay(Way way) {
+        final OsmConvertDefaults.OsmWayDefaults defaults = getWayDefaults(way);
 
-		final boolean forward = isForward(way, defaults);
-		final boolean backward = isBackward(way, defaults);
-		final Double freespeed = getFreespeed(way, defaults);
-		final Double nofLanesPerDirection = getLanesPerDirection(way, defaults, forward, backward);
-		final Double capacity = getCapacity(way, defaults, nofLanesPerDirection);
-		final Set<String> modes = getModes(way, defaults);
+        final boolean forward = isForward(way, defaults);
+        final boolean backward = isBackward(way, defaults);
+        final Double freespeed = getFreespeed(way, defaults);
+        final Double nofLanesPerDirection = getLanesPerDirection(way, defaults, forward, backward);
+        final Double capacity = getCapacity(way, defaults, nofLanesPerDirection);
+        final Set<String> modes = getModes(way, defaults);
 
-		return capacity != null && freespeed != null && nofLanesPerDirection != null && modes != null;
-	}
+        return capacity != null && freespeed != null && nofLanesPerDirection != null && modes != null;
+    }
 
-	static Double getTaggedLength(Way way) {
-		Double taggedLength = null;
-		if (way.getKeys().containsKey(LENGTH)) {
-			taggedLength = parseDoubleIfPossible(way.getKeys().get(LENGTH));
-		}
-		return taggedLength;
-	}
+    static Double getTaggedLength(Way way) {
+        Double taggedLength = null;
+        if (way.getKeys().containsKey(LENGTH)) {
+            taggedLength = parseDoubleIfPossible(way.getKeys().get(LENGTH));
+        }
+        return taggedLength;
+    }
 
-	static Double parseDoubleIfPossible(String string) {
-		try {
-			return Double.parseDouble(string);
-		} catch (NumberFormatException e) {
-			return null;
-		}
-	}
+    static Double parseDoubleIfPossible(String string) {
+        try {
+            return Double.parseDouble(string);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
 
-	static OsmConvertDefaults.OsmWayDefaults getWayDefaults(Way way) {
-		String wayType = null;
-		if (way.getKeys().containsKey(NetworkModel.TAG_HIGHWAY)) {
-			wayType = way.getKeys().get(NetworkModel.TAG_HIGHWAY);
-		} else if (way.getKeys().containsKey(NetworkModel.TAG_RAILWAY)) {
-			wayType = way.getKeys().get(NetworkModel.TAG_RAILWAY);
-		}
-		return wayType != null ? OsmConvertDefaults.getWayDefaults().get(wayType) : null;
-	}
+    static OsmConvertDefaults.OsmWayDefaults getWayDefaults(Way way) {
+        String wayType = null;
+        if (way.getKeys().containsKey(NetworkModel.TAG_HIGHWAY)) {
+            wayType = way.getKeys().get(NetworkModel.TAG_HIGHWAY);
+        } else if (way.getKeys().containsKey(NetworkModel.TAG_RAILWAY)) {
+            wayType = way.getKeys().get(NetworkModel.TAG_RAILWAY);
+        }
+        return wayType != null ? OsmConvertDefaults.getWayDefaults().get(wayType) : null;
+    }
+
+    //based on the scheme from The TUM Accessibility Atlas: Visualizing Spatial and
+    // Socioeconomic Disparities in Accessibility to Support Regional Land-Use and
+    // Transport Planning
+    // (https://link.springer.com/content/pdf/10.1007%2Fs11067-017-9378-6.pdf)
+
+    static String getHbefaType(Way way, OsmConvertDefaults.OsmWayDefaults defaults) {
+
+        String hbefaType = null;
+        if (way.getKeys().containsKey(HBEFA)) {
+            hbefaType = way.getKeys().get(HBEFA);
+        }
+
+        if (hbefaType == null) {
+            Double freespeed = getFreespeed(way, defaults);
+            String highway = way.getKeys().get("highway");
+
+            if (highway.equals("motorway") || highway.equals("motorway_link")) {
+                hbefaType = String.format("%s/%d", "Urban/Motor", Math.round(freespeed * 3.6));
+            } else if (highway.equals("primary") || highway.equals("primary_link") || highway.equals("trunk") || highway.equals("trunk_link")) {
+                hbefaType = String.format("%s/%d", "Urban/Trunk", Math.round(freespeed * 3.6));
+            } else if (highway.equals("secondary") || highway.equals("secondary_link")) {
+                hbefaType = String.format("%s/%d", "Urban/Distributor", Math.round(freespeed * 3.6));
+            } else if (highway.equals("tertiary") || highway.equals("tertiary_link")) {
+                hbefaType = String.format("%s/%d", "Urban/Trunk", Math.round(freespeed * 3.6));
+            } else {
+                hbefaType = String.format("%s/%d", "Urban/Access-residential", Math.round(freespeed * 3.6));
+            }
+        }
+        return hbefaType;
+    }
 }

--- a/src/main/java/org/matsim/contrib/josm/model/MLink.java
+++ b/src/main/java/org/matsim/contrib/josm/model/MLink.java
@@ -19,6 +19,7 @@ public class MLink {
 	private MNode fromNode;
 	private MNode toNode;
 	private String type;
+	private String hbefaType;
 
 	public MLink(MNode fromNode, MNode toNode) {
 
@@ -82,13 +83,20 @@ public class MLink {
 		return segments;
 	}
 
-
 	public void setType(String type) {
 		this.type = type;
 	}
 
 	public String getType() {
 		return type;
+	}
+
+	public void setHbefaType(String hbefaType) {
+		this.hbefaType = hbefaType;
+	}
+
+	public String getHbefaType() {
+		return hbefaType;
 	}
 
 	public Id<Link> getId() {

--- a/src/main/java/org/matsim/contrib/josm/model/NetworkModel.java
+++ b/src/main/java/org/matsim/contrib/josm/model/NetworkModel.java
@@ -313,6 +313,7 @@ public class NetworkModel {
 			final Double capacity = LinkConversionRules.getCapacity(way, defaults, nofLanesPerDirection);
 			final Set<String> modes = LinkConversionRules.getModes(way, defaults);
 			final String highwayType = LinkConversionRules.getType(way, defaults);
+			final String hbefaType = LinkConversionRules.getHbefaType(way, defaults);
 
 			final Double taggedLength = LinkConversionRules.getTaggedLength(way);
 
@@ -355,6 +356,7 @@ public class NetworkModel {
 							l.setOrigId(origId);
 							l.setSegments(segs);
 							l.setType(highwayType);
+							l.setHbefaType(hbefaType);
 							links.add(l);
 						}
 						if (backward) {
@@ -369,6 +371,7 @@ public class NetworkModel {
 							l.setOrigId(origId);
 							l.setSegments(segs);
 							l.setType(highwayType);
+							l.setHbefaType(hbefaType);
 							l.setReverseWayDirection(true);
 							links.add(l);
 						}

--- a/src/main/java/org/matsim/contrib/josm/model/OsmConvertDefaults.java
+++ b/src/main/java/org/matsim/contrib/josm/model/OsmConvertDefaults.java
@@ -17,7 +17,7 @@ public class OsmConvertDefaults {
 	private static final Map<String, OsmWayDefaults> wayDefaults = new HashMap<>();
 
 	public static final List<String> highwayTypes = Arrays.asList("motorway", "motorway_link", "trunk", "trunk_link", "primary", "primary_link",
-			"secondary", "tertiary", "minor", "unclassified", "residential", "service", "living_street");
+			"secondary", "secondary_link", "tertiary", "tertiary_link", "minor", "unclassified", "residential", "service", "living_street");
 
 	private static final Map<String, StringProperty> properties = new HashMap<>();
 
@@ -48,7 +48,9 @@ public class OsmConvertDefaults {
 		properties.put("primary", new StringProperty("matsim_convertDefaults_primary", "3;1;" + Double.toString(80. / 3.6) + ";1.0;1500;false"));
 		properties.put("primary_link", new StringProperty("matsim_convertDefaults_primary_link", "3;1;" + Double.toString(60. / 3.6) + ";1.0;1500;false"));
 		properties.put("secondary", new StringProperty("matsim_convertDefaults_secondary", "4;1;" + Double.toString(60. / 3.6) + ";1.0;1000;false"));
+		properties.put("secondary_link", new StringProperty("matsim_convertDefaults_secondary_link", "4;1;" + Double.toString(60. / 3.6) + ";1.0;1000;false"));
 		properties.put("tertiary", new StringProperty("matsim_convertDefaults_tertiary", "5;1;" + Double.toString(45. / 3.6) + ";1.0;600;false"));
+		properties.put("tertiary_link", new StringProperty("matsim_convertDefaults_tertiary", "5;1;" + Double.toString(45. / 3.6) + ";1.0;600;false"));
 		properties.put("minor", new StringProperty("matsim_convertDefaults_minor", "6;1;" + Double.toString(45. / 3.6) + ";1.0;600;false"));
 		properties.put("unclassified", new StringProperty("matsim_convertDefaults_unclassified", "6;1;" + Double.toString(45. / 3.6) + ";1.0;600;false"));
 		properties.put("residential", new StringProperty("matsim_convertDefaults_residential", "6;1;" + Double.toString(30. / 3.6) + ";1.0;600;false"));


### PR DESCRIPTION
1. Transform OSM road type to HBEFA road type
2. Create new attribute of HBEFA road type in network file
3. Transforation scheme is based on the scheme from The TUM Accessibility Atlas: Visualizing Spatial and Socioeconomic Disparities in Accessibility to Support Regional Land-Use and Transport Planning (https://link.springer.com/content/pdf/10.1007%2Fs11067-017-9378-6.pdf)