### PR TITLE
Add GitLab CI configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,150 @@
+image: registry.gitlab.com/josm/docker-library/openjdk-8-josmplugin-openjfx:latest
+
+stages:
+  - build
+  - test
+  - deploy
+  - release
+
+assemble:
+  stage: build
+  variables:
+    OPENJFX_CLASSPATH: "/usr/share/java/openjfx/jre/lib/ext/jfxrt.jar"
+  script:
+    - ./gradlew assemble --stacktrace
+  artifacts:
+    paths:
+      - build/
+  except:
+    - schedules
+
+java 11 assemble:
+  stage: build
+  image: registry.gitlab.com/josm/docker-library/openjdk-11-josmplugin:latest
+  script:
+    - ./gradlew assemble --stacktrace
+  artifacts:
+    paths:
+      - build/
+  except:
+    - schedules
+
+build:
+  stage: test
+  variables:
+    OPENJFX_CLASSPATH: "/usr/share/java/openjfx/jre/lib/ext/jfxrt.jar"
+  script:
+    - ./gradlew build generatePot --stacktrace
+  artifacts:
+    paths:
+      - build/
+  dependencies:
+    - assemble
+  except:
+    - schedules
+
+java 11 build:
+  stage: test
+  image: registry.gitlab.com/josm/docker-library/openjdk-11-josmplugin:latest
+  script:
+    - ./gradlew build --stacktrace
+  dependencies:
+    - java 11 assemble
+  except:
+    - schedules
+
+min JOSM compile:
+  stage: test
+  image: registry.gitlab.com/josm/docker-library/openjdk-11-josmplugin:latest
+  script:
+    - ./gradlew compileJava_minJosm --stacktrace
+  dependencies:
+    - java 11 assemble
+  except:
+    - schedules
+
+latest JOSM compile:
+  stage: test
+  image: registry.gitlab.com/josm/docker-library/openjdk-11-josmplugin:latest
+  script:
+    - ./gradlew compileJava_latestJosm --stacktrace
+  only:
+    - schedules
+
+upload to transifex:
+  image: registry.gitlab.com/josm/docker-library/python-transifex:latest
+  stage: deploy
+  environment:
+    name: transifex
+    url: https://www.transifex.com/josm/josm/josm-plugin_matsim/
+  script:
+    - TX_TOKEN="$TRANSIFEX_TOKEN" tx push -s --no-interactive
+  dependencies:
+    - build
+  only:
+    - master@JOSM/plugin/matsim
+  except:
+    - schedules
+
+package to GitLab.com:
+  stage: deploy
+  variables:
+    OPENJFX_CLASSPATH: "/usr/share/java/openjfx/jre/lib/ext/jfxrt.jar"
+  environment:
+    name: GitLab.com / Maven packages
+    url: https://gitlab.com/JOSM/plugin/matsim/-/packages
+  script:
+    - ./gradlew publishAllPublicationsToGitlabRepository
+  dependencies:
+    - build
+  only:
+    - tags@JOSM/plugin/matsim
+  except:
+    - schedules
+
+push GitLab.com pages branch:
+  stage: deploy
+  environment:
+    name: GitLab.com / pages branch
+    url: https://gitlab.com/JOSM/plugin/matsim/tree/pages/dist
+  script:
+    - |
+      base64 --decode "$SSH_PRIVATE_DEPLOY_KEY" > ~/.ssh/id_rsa
+      chmod 600 ~/.ssh/id_rsa
+      git clone --depth 1 --branch pages git@gitlab.com:JOSM/plugin/matsim.git pages
+    - |
+      version=`git describe --always --dirty`
+      longVersion=`git describe --always --long --dirty`
+      commitMessage="Release version $longVersion"
+    - |
+      mkdir -pv "pages/dist/$version"
+      cp -v build/dist/* build/tmp/jar/MANIFEST.MF "pages/dist/$version"
+      rm -fv "pages/dist/latest"
+      ln -s "./$version" "pages/dist/latest"
+    - |
+      cd pages/
+      git config user.name "Deploy with GitLab CI"
+      git config user.email "deploy@gitlab.com"
+      git stage .
+      git commit -a -m "$commitMessage"
+      git push origin pages
+  dependencies:
+    - build
+  only:
+    - tags@JOSM/plugin/matsim
+
+release to Gitlab.com:
+  stage: release
+  variables:
+    OPENJFX_CLASSPATH: "/usr/share/java/openjfx/jre/lib/ext/jfxrt.jar"
+  environment:
+    name: GitLab.com / Releases
+    url: https://gitlab.com/JOSM/plugin/matsim/-/releases
+  script:
+    - ./gradlew releaseToGitlab
+  dependencies:
+    - package to GitLab.com
+  only:
+    - tags@JOSM/plugin/matsim
+  except:
+    - schedules

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ jdk:
   - oraclejdk8
   - oraclejdk9
 script:
-  - ./gradlew build compileJava_minJosm
-  - ./gradlew build compileJava_latestJosm
+  - ./gradlew compileJava_minJosm
+  - ./gradlew compileJava_latestJosm
+  - ./gradlew build
 
 deploy:
   provider: releases
@@ -19,28 +20,3 @@ deploy:
     condition: -n $GH_TOKEN
     tags: true
     jdk: oraclejdk8
-
-jobs:
-  include:
-    - stage: i18n
-      language: python
-      python: "3.6"
-      install: pip install git+https://github.com/transifex/transifex-client.git@699dd42e04074be92a07b5b87e8f1ea672a6571f#egg=transifex-client
-      script: |
-        if [ ! -z "$TRANSIFEX_TOKEN" ]; then
-          ./gradlew generatePot
-          tx --token="$TRANSIFEX_TOKEN" --force-save --no-interactive init
-          git checkout HEAD .tx/config
-          tx push -s --no-interactive
-        fi
-
-stages:
-  - test
-  - name: i18n
-    if: type = push AND branch = master
-
-matrix:
-  fast_finish: true
-  allow_failures:
-  - jdk: oraclejdk9
-  - language: python

--- a/.tx/config
+++ b/.tx/config
@@ -5,6 +5,6 @@ host = https://www.transifex.com
 file_filter = src/main/po/<lang>.po
 lang_map = ca@valencia: ca-valencia
 minimum_perc=40
-source_file = build/i18n/josm-plugin_matsim.pot
+source_file = build/i18n/pot/josm-plugin_matsim.pot
 source_lang = en
 type = PO

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.openstreetmap.josm' version '0.6.4'
+    id("org.openstreetmap.josm").version("0.6.5")
     id 'java'
     id 'eclipse'
     id 'idea'
@@ -13,16 +13,6 @@ repositories {
         content {
             includeGroup("org.matsim")
             includeGroup("org.matsim.contrib")
-        }
-    }
-    maven {
-        // This repository is only needed for GeoTools dependencies that are not excluded when compiling against minJosm/latestJosm/testedJosm in gradle-josm-plugin <= 0.6.4.
-        // As soon as a new version of that plugin is released, this `maven{}` block can be removed
-        url("https://download.osgeo.org/webdav/geotools")
-        content {
-            includeGroup("javax.media")
-            includeGroup("jgridshift")
-            includeGroup("org.geotools")
         }
     }
     maven {
@@ -44,6 +34,10 @@ configurations.packIntoJar {
 }
 
 dependencies {
+    def openjfxClasspath = System.getenv("OPENJFX_CLASSPATH")
+    if (openjfxClasspath != null) {
+        implementation(files(openjfxClasspath))
+    }
     packIntoJar ('org.matsim:matsim:11.0') {changing = true}
     packIntoJar ('org.matsim.contrib:otfvis:11.0') {changing = true}
     packIntoJar ('org.matsim.contrib:emissions:11.0') {changing = true}


### PR DESCRIPTION
I'm mirroring some JOSM plugins to GitLab.com: https://gitlab.com/JOSM (normally branches that you push to GitHub need about 10 minutes until they are on GitLab)

This configuration would then automatically
* trigger a CI pipeline with OpenJDK 8 and OpenJDK 11 in GitLab (https://gitlab.com/JOSM/plugin/matsim/pipelines/94915961).
* once a week a pipeline is started to check if the plugin compiles against JOSM-latest
* for the master branch: push new translatable strings to Transifex
* for tags: publish a new release to [GitLab releases](https://gitlab.com/JOSM/plugin/matsim/-/releases), the [GitLab Maven repository](https://gitlab.com/JOSM/plugin/matsim/-/packages) and [a stable URL](https://josm.gitlab.io/plugin/matsim/dist/latest/matsim.jar) that could then be used in https://josm.openstreetmap.de/wiki/PluginsSource without changing it for every release